### PR TITLE
need to store time in double

### DIFF
--- a/py/datastore_service.py
+++ b/py/datastore_service.py
@@ -157,7 +157,7 @@ class StoreHandler(BaseHTTPRequestHandler):
           speed = 0.0
         else:
           #kph
-          speed = round((length / (seconds * 1.0))*3.6,2)
+          speed = round((length / seconds) * 3.6, 2)
 
         # send it to the cursor.
         thread_local.sql_conn.cursor().execute("execute report (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",

--- a/py/datastore_service.py
+++ b/py/datastore_service.py
@@ -32,7 +32,10 @@ class ThreadPoolMixIn(ThreadingMixIn):
 
   def serve_forever(self):
     # set up the threadpool
-    pool_size = int(os.environ.get('THREAD_POOL_MULTIPLIER', 1)) * multiprocessing.cpu_count()
+    if 'THREAD_POOL_COUNT' in os.environ:
+      pool_size = int(os.environ.get('THREAD_POOL_COUNT'))
+    else:
+      pool_size = int(os.environ.get('THREAD_POOL_MULTIPLIER', 1)) * multiprocessing.cpu_count()
     self.requests = Queue(pool_size)
     for x in range(pool_size):
       t = threading.Thread(target = self.process_request_thread)
@@ -226,8 +229,8 @@ def initialize_db():
           sys.stdout.write('Creating tables.' + os.linesep)
           sys.stdout.flush()
           cursor.execute('CREATE TABLE segments(segment_id bigint, prev_segment_id bigint, ' \
-                         'mode text,start_time integer,start_time_dow smallint, start_time_hour smallint, ' \
-                         'end_time integer, end_time_dow smallint, end_time_hour smallint, length integer, ' \
+                         'mode text,start_time double precision ,start_time_dow smallint, start_time_hour smallint, ' \
+                         'end_time double precision, end_time_dow smallint, end_time_hour smallint, length integer, ' \
                          'speed float, provider text); ' \
                          'CREATE INDEX index_ids ON segments (segment_id);' \
                          'CREATE INDEX index_ids_dates ON segments (segment_id,start_time,end_time);' \


### PR DESCRIPTION
double is the only safe way to store epoch times also rounding to seconds is important on small segments. this also allows one to set the exact number of threads they want to use