### PR TITLE
Datastore script to receive units of work from AWS Batch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ MAINTAINER Grant Heffernan <grant@mapzen.com>
 ENV DEBIAN_FRONTEND noninteractive
 
 # install dependencies
-RUN apt-get update && apt-get install -y default-jdk python python-pip maven
-RUN pip install --upgrade pip
-RUN pip install boto3 argparse
+RUN apt-get update && apt-get install -y default-jdk python3 python3-pip maven
+RUN pip3 install --upgrade pip
+RUN pip3 install boto3 argparse
 
 # install scripts
 ADD ./scripts /scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:16.10
 MAINTAINER Grant Heffernan <grant@mapzen.com>
 
 # env

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ ADD ./scripts /scripts
 
 # install java code
 ADD ./src /datastore/src
-ADD ./tests /datastore/tests
 ADD ./pom.xml /datastore/pom.xml
 
 # compile java

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ADD ./scripts /scripts
 
 # install java code
 ADD ./src /datastore/src
+ADD ./tests /datastore/tests
 ADD ./pom.xml /datastore/pom.xml
 
 # compile java

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.10
+FROM ubuntu:17.04
 MAINTAINER Grant Heffernan <grant@mapzen.com>
 
 # env

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -4,7 +4,7 @@ import os
 import sys
 import boto3
 import argparse
-#import subprocess
+import subprocess
 
 def cleanup():
     pass
@@ -30,9 +30,7 @@ def convert(keys_array):
 
     # TODO: error handling?
     sys.stdout.flush()
-    #process = subprocess.run(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, check=True)
-    cmd = 'datastore-histogram-tile-writer --time-bucket ' + str(args.time_bucket) + ' --tile ' + str(args.tile_id) + ' -f flatbuffer_file -o orc_file ' + file_list'
-    process = os.system(cmd)
+    process = subprocess.run(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, check=True)
     print('[INFO] Finished running conversion')
 
 def download(keys_array):

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -31,7 +31,7 @@ def convert(keys_array):
     # TODO: error handling?
     sys.stdout.flush()
     #process = subprocess.run(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, check=True)
-    cmd = 'datastore-histogram-tile-writer --time-bucket ' + str(args.time_bucket) + ' --tile ' + str(args.tile_id) + ' -f flatbuffer_file -o orc_file ' + file_list
+    cmd = 'datastore-histogram-tile-writer --time-bucket ' + str(args.time_bucket) + ' --tile ' + str(args.tile_id) + ' -f flatbuffer_file -o orc_file ' + file_list'
     process = os.system(cmd)
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -30,7 +30,7 @@ def convert():
     #cmd = 'echo WHAT_IS_GOING_ON'
 
     sys.stdout.flush()
-    process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+    process = subprocess.run(cmd, shell=True, timeout=300, check=True, stdout=PIPE, stderr=PIPE)
     process.wait()
     print '[INFO] Finished running conversion, return code: ' + str(process.returncode)
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -20,7 +20,8 @@ def upload():
     s3_client = boto3.client('s3')
     uploads = glob.glob('*.fb')
     for file in uploads:
-        response = s3_client.put_object(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream')
+        data = open(file, 'rb')
+        response = s3_client.put_object(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream', Body = data)
 
 def convert():
     # TODO: error handling?

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -30,7 +30,7 @@ def convert(keys_array):
 
     # TODO: error handling?
     sys.stdout.flush()
-    process = subprocess.run(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, check=True)
+    process = subprocess.run(['datastore-histogram-tile-writer', '-v', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, check=True)
     print('[INFO] Finished running conversion')
 
 def download(keys_array):

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -20,7 +20,7 @@ def upload():
     s3_client = boto3.client('s3')
     uploads = glob.glob('*.fb')
     for file in uploads:
-        response = s3_client.upload_file(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream')
+        response = s3_client.put_object(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream')
 
 def convert():
     # TODO: error handling?

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -26,7 +26,7 @@ def convert():
     # TODO: error handling?
     sys.stdout.flush()
 
-    process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file'] + glob.glob('*'), timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
+    process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file'] + glob.glob('*'), timeout=180, universal_newlines=True, stderr=subprocess.STDOUT)
 
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -17,6 +17,7 @@ def cleanup():
     #    )
 
 def upload():
+    # TODO: upload pathing?
     s3_client = boto3.client('s3')
     uploads = glob.glob('*.fb')
     for file in uploads:
@@ -25,11 +26,16 @@ def upload():
         data.close()
 
 def convert():
-    # TODO: error handling?
     sys.stdout.flush()
 
+    # TODO: still not getting any 
     fb_out_file = 'flatbuffer_' + str(args.tile_id) + '.fb'
-    process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', fb_out_file] + glob.glob('*'), timeout=180, universal_newlines=True, stderr=subprocess.STDOUT)
+
+    try:
+        process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', fb_out_file] + glob.glob('*'), timeout=180, universal_newlines=True, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as tilewriter:
+        print('[ERROR] Failed running datastore-histogram-tile-writer:', tilewriter.returncode, tilewriter.output)
+        sys.exit([tilewriter.returncode])
 
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -8,7 +8,7 @@ import boto3
 import argparse
 import subprocess
 
-def cleanup():
+def cleanup(delete_array):
     # print('[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket)
     pass
     # delete the original keys from the s3_reporter_bucket
@@ -39,6 +39,7 @@ def convert():
     fb_out_file = str(args.tile_index) + '.fb'
     orc_out_file = str(args.tile_index) + '.orc'
 
+    # TODO: no idea if the exception handling works
     try:
         process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', fb_out_file, '-o', orc_out_file] + glob.glob('*'), timeout=180, universal_newlines=True, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as tilewriter:
@@ -64,6 +65,9 @@ def download(keys_array):
         s3_resource.Object(args.s3_reporter_bucket, key).download_file(object_id)
         delete_array.append( { 'Key': key } )
 
+    # TODO: untested
+    return delete_array
+
 if __name__ == "__main__":
     # build args
     parser = argparse.ArgumentParser()
@@ -84,9 +88,9 @@ if __name__ == "__main__":
     print('[INFO] tile index: ' + str(args.tile_index))
 
     # do work
-    download(args.s3_reporter_keys.split(','))
+    delete_list = download(args.s3_reporter_keys.split(','))
     convert()
     upload()
-    cleanup()
+    cleanup(delete_list)
 
     print('[INFO] run complete')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import time
 import glob
 import boto3
 import argparse
@@ -16,23 +17,26 @@ def cleanup():
     #    Delete = { 'Objects': delete_array }
     #    )
 
-def upload():
-    # TODO: upload pathing?
+def upload(time):
+    # ex path key: year/month/day/hour/tile_level/tile_index.fb
+    to_time = time.gmtime(args.time_bucket * 3600)
+    time_path = str(to_time[0]) + '/' + str(to_time[1]) + '/' + str(to_time[2]) + '/' + str(to_time[3]) + str(args.tile_level) + '/'
+
     s3_client = boto3.client('s3')
-    uploads = glob.glob('*.fb')
+    uploads = [str(args.tile_index) + '.fb ', str(args.tile_index) + '.orc']
     for file in uploads:
         data = open(file, 'rb')
-        response = s3_client.put_object(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream', Body = data)
+        response = s3_client.put_object(Bucket = args.s3_datastore_bucket, ContentType = 'binary/octet-stream', Body = data, Key = time_path + file)
         data.close()
 
 def convert():
     sys.stdout.flush()
 
-    # TODO: still not getting any 
-    fb_out_file = 'flatbuffer_' + str(args.tile_id) + '.fb'
+    fb_out_file = str(args.tile_index) + '.fb'
+    orc_out_file = str(args.tile_index) + '.orc'
 
     try:
-        process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', fb_out_file] + glob.glob('*'), timeout=180, universal_newlines=True, stderr=subprocess.STDOUT)
+        process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', fb_out_file, '-o', orc_out_file] + glob.glob('*'), timeout=180, universal_newlines=True, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as tilewriter:
         print('[ERROR] Failed running datastore-histogram-tile-writer:', tilewriter.returncode, tilewriter.output)
         sys.exit([tilewriter.returncode])
@@ -64,12 +68,16 @@ if __name__ == "__main__":
     parser.add_argument('s3_reporter_keys', type=str, help='S3 object keys which we will operate on, found in the s3_reporter_bucket')
     parser.add_argument('time_bucket', type=int, help='The time bucket')
     parser.add_argument('tile_id', type=int, help='The tile ID')
+    parser.add_argument('tile_level', type=int, help='The tile level')
+    parser.add_argument('tile_index', type=int, help='The tile index')
     args = parser.parse_args()
 
     print('[INFO] reporter intput bucket: ' + args.s3_reporter_bucket)
     print('[INFO] datastore output bucket: ' + args.s3_datastore_bucket)
     print('[INFO] time bucket: ' + str(args.time_bucket))
-    print('[INFO] tile: ' + str(args.tile_id))
+    print('[INFO] tile id: ' + str(args.tile_id))
+    print('[INFO] tile level: ' + str(args.tile_level))
+    print('[INFO] tile index: ' + str(args.tile_index))
 
     # download stuff
     print('[INFO] downloading data from s3')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import boto3
-import signal
 import argparse
 import subprocess
 
@@ -25,10 +24,12 @@ def upload():
 def convert():
     # TODO: error handling?
     sys.stdout.flush()
-
-    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', '/work/flatbuffer_file', '-o', '/work/orc_file', '/work/*'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
-    process.terminate()
-
+    sys.stderr.flush()
+    #process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', '/work/flatbuffer_file', '-o', '/work/orc_file', '/work/*'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
+    cmd = 'datastore-histogram-tile-writer -b ' + str(args.time_bucket) + ' -t ' + str(args.tile_id) + ' -v ' + '-f ' + '/work/flatbuffer_file ' + '-o ' + '/work/orc_file ' + '/work/*'
+    process = subprocess.run(cmd, timeout=300, universal_newlines=True, stderr=subprocess.STDOUT, shell=True)
+    sys.stdout.flush()
+    sys.stderr.flush()
     print('[INFO] Finished running conversion')
 
 def download(keys_array):

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -21,16 +21,10 @@ def upload():
     for file in uploads:
         response = s3_client.put_object(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream')
 
-def convert(keys_array):
-    id_array = []
-    for key in keys_array:
-        id_array.append(key.rsplit('/', 1)[-1])
-
-    file_list = ' '.join(id_array)
-
+def convert():
     # TODO: error handling?
     sys.stdout.flush()
-    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, cwd='/work', universal_newlines=True, stderr=subprocess.STDOUT)
+    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', '/work/flatbuffer_file', '-o', '/work/orc_file', '/work/*'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
     print('[INFO] Finished running conversion')
 
 def download(keys_array):

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -23,7 +23,7 @@ def upload():
 
     # ex path key: year/month/day/hour/tile_level/tile_index.fb
     to_time = time.gmtime(args.time_bucket * 3600)
-    time_path = str(to_time[0]) + '/' + str(to_time[1]) + '/' + str(to_time[2]) + '/' + str(to_time[3]) + str(args.tile_level) + '/'
+    time_key = str(to_time[0]) + '/' + str(to_time[1]) + '/' + str(to_time[2]) + '/' + str(to_time[3]) + str(args.tile_level) + '/' + str(args.tile_index)
 
     s3_client = boto3.client('s3')
 
@@ -35,7 +35,7 @@ def upload():
 
     for file in files_grabbed:
         data = open(file, 'rb')
-        response = s3_client.put_object(Bucket = args.s3_datastore_bucket, ContentType = 'binary/octet-stream', Body = data, Key = time_path + str(args.tile_index))
+        response = s3_client.put_object(Bucket = args.s3_datastore_bucket, ContentType = 'binary/octet-stream', Body = data, Key = time_key)
         data.close()
 
 def convert():

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -22,12 +22,17 @@ def upload():
     for file in uploads:
         response = s3_client.put_object(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream')
 
-def convert():
+def convert(keys_array):
+    id_array = []
+    for key in keys_array:
+        id_array.append('/work/' + key.rsplit('/', 1)[-1])
+
+    file_list = ' '.join(id_array)
+
     # TODO: error handling?
     sys.stdout.flush()
 
-    cmd = 'datastore-histogram-tile-writer -v -b ' + str(args.time_bucket) + ' -t ' + str(args.tile_id) + ' -f /work/flatbuffer_file ' + '-o /work/orc_file /work/*'
-    proc = subprocess.check_output(cmd, timeout=300, universal_newlines=True, shell=True)
+    process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, universal_newlines=True)
 
     print('[INFO] Finished running conversion')
 
@@ -69,7 +74,7 @@ if __name__ == "__main__":
 
     # convert stuff
     print('[INFO] running conversion process')
-    convert()
+    convert(args.s3_reporter_keys.split(','))
 
     # TODO: upload the result to s3_datastore_bucket
     print('[INFO] uploading resulting files')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -1,6 +1,7 @@
-#!/usr/bin/env python3 -u
+#!/usr/bin/env python3
 
 import os
+import sys
 import glob
 import boto3
 import signal
@@ -24,6 +25,8 @@ def upload():
 
 def convert():
     # TODO: error handling?
+    sys.stdout.flush()
+
     process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file'] + glob.glob('*'), timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
 
     print('[INFO] Finished running conversion')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -9,6 +9,7 @@ import argparse
 import subprocess
 
 def cleanup():
+    # print('[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket)
     pass
     # delete the original keys from the s3_reporter_bucket
     #print('[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket)
@@ -17,7 +18,9 @@ def cleanup():
     #    Delete = { 'Objects': delete_array }
     #    )
 
-def upload(time):
+def upload():
+    print('[INFO] uploading resulting files')
+
     # ex path key: year/month/day/hour/tile_level/tile_index.fb
     to_time = time.gmtime(args.time_bucket * 3600)
     time_path = str(to_time[0]) + '/' + str(to_time[1]) + '/' + str(to_time[2]) + '/' + str(to_time[3]) + str(args.tile_level) + '/'
@@ -30,6 +33,7 @@ def upload(time):
         data.close()
 
 def convert():
+    print('[INFO] running conversion process')
     sys.stdout.flush()
 
     fb_out_file = str(args.tile_index) + '.fb'
@@ -55,7 +59,7 @@ def download(keys_array):
     s3_resource = boto3.resource('s3')
     for key in keys_array:
         object_id = key.rsplit('/', 1)[-1]
-        print('[INFO] Downloading ' + object_id + ' from s3')
+        print('[INFO] downloading ' + object_id + ' from s3')
 
         s3_resource.Object(args.s3_reporter_bucket, key).download_file(object_id)
         delete_array.append( { 'Key': key } )
@@ -79,20 +83,10 @@ if __name__ == "__main__":
     print('[INFO] tile level: ' + str(args.tile_level))
     print('[INFO] tile index: ' + str(args.tile_index))
 
-    # download stuff
-    print('[INFO] downloading data from s3')
+    # do work
     download(args.s3_reporter_keys.split(','))
-
-    # convert stuff
-    print('[INFO] running conversion process')
     convert()
-
-    # TODO: upload the result to s3_datastore_bucket
-    print('[INFO] uploading resulting files')
     upload()
-    
-    # TODO: cleanup stuff
-    print('[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket)
     cleanup()
 
     print('[INFO] run complete')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -47,7 +47,7 @@ for key in keys_array:
 
 # TODO: error handling?
 print '[INFO] running conversion process'
-cmd = 'datastore-histogram-tile-writer --time-bucket' + str(args.time_bucket) + '--tile' + str(args.tile_id) + '-f flatbuffer_file -o orc_file ./*'
+cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + ' --tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file ./*'
 call(cmd, shell = True)
 #call(['touch', 'YAY_IT_WORKS'])
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -18,7 +18,7 @@ def cleanup():
 
 def upload():
     s3_client = boto3.client('s3')
-    uploads = ['flatbuffer_file', 'orc_file']
+    uploads = glob.glob('*.fb')
     for file in uploads:
         response = s3_client.put_object(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream')
 
@@ -26,7 +26,8 @@ def convert():
     # TODO: error handling?
     sys.stdout.flush()
 
-    process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file'] + glob.glob('*'), timeout=180, universal_newlines=True, stderr=subprocess.STDOUT)
+    fb_out_file = 'flatbuffer_' + str(args.tile_id) + '.fb'
+    process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', fb_out_file] + glob.glob('*'), timeout=180, universal_newlines=True, stderr=subprocess.STDOUT)
 
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -26,7 +26,7 @@ def convert():
     # TODO: error handling?
     sys.stdout.flush()
 
-    cmd = 'datastore-histogram-tile-writer -v -b ' + str(args.time_bucket) + '-t ' + str(args.tile_id) + ' -f /work/flatbuffer_file ' + '-o /work/orc_file /work/*'
+    cmd = 'datastore-histogram-tile-writer -v -b ' + str(args.time_bucket) + ' -t ' + str(args.tile_id) + ' -f /work/flatbuffer_file ' + '-o /work/orc_file /work/*'
     proc = subprocess.run(cmd, timeout=300, universal_newlines=True, stderr=subprocess.STDOUT, shell=True)
     out,err = proc.communicate()
     print(out)

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -25,7 +25,7 @@ def upload():
 def convert(keys_array):
     id_array = []
     for key in keys_array:
-        id_array.append('/work/' + key.rsplit('/', 1)[-1])
+        id_array.append(key.rsplit('/', 1)[-1])
 
     file_list = ' '.join(id_array)
 
@@ -33,7 +33,7 @@ def convert(keys_array):
     sys.stdout.flush()
 
     #process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
-    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', '/work/opentraffic.2c45aa7a-9171-4e4a-9ddc-f6128293450f'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
+    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', 'opentraffic.2c45aa7a-9171-4e4a-9ddc-f6128293450f'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
 
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -31,7 +31,7 @@ def convert(keys_array):
     # TODO: error handling?
     sys.stdout.flush()
     #process = subprocess.run(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, check=True)
-    cmd = 'datastore-histogram-tile-writer --time-bucket ' + str(args.time_bucket) + ' --tile ' + str(args.tile_id) + ' -f flatbuffer_file -o orc_file ' + file_list'
+    cmd = 'datastore-histogram-tile-writer --time-bucket ' + str(args.time_bucket) + ' --tile ' + str(args.tile_id) + ' -f flatbuffer_file -o orc_file ' + file_list
     process = os.system(cmd)
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -19,22 +19,16 @@ def cleanup():
     #    )
 
 def upload():
-    print('[INFO] uploading resulting files')
-
-    # ex path key: year/month/day/hour/tile_level/tile_index.fb
-    to_time = time.gmtime(args.time_bucket * 3600)
-    time_key = str(to_time[0]) + '/' + str(to_time[1]) + '/' + str(to_time[2]) + '/' + str(to_time[3]) + str(args.tile_level) + '/' + str(args.tile_index)
-
+    print('[INFO] uploading data')
     s3_client = boto3.client('s3')
 
-    # glob our upload data
-    local_types = ('*.fb', '*.orc')
-    files_grabbed = []
-    for f in local_types:
-        files_grabbed.extend(glob.glob(f))
+    uploads = ['.fb', '.orc']
+    for file_extension in uploads:
+        # ex path key: year/month/day/hour/tile_level/tile_index.fb
+        to_time = time.gmtime(args.time_bucket * 3600)
+        time_key = str(to_time[0]) + '/' + str(to_time[1]) + '/' + str(to_time[2]) + '/' + str(to_time[3]) + str(args.tile_level) + '/' + str(args.tile_index) + file_extension
 
-    for file in files_grabbed:
-        data = open(file, 'rb')
+        data = open(str(args.tile_index) + file_extension, 'rb')
         response = s3_client.put_object(Bucket = args.s3_datastore_bucket, ContentType = 'binary/octet-stream', Body = data, Key = time_key)
         data.close()
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -4,7 +4,6 @@ import os
 import sys
 import glob
 import boto3
-import signal
 import argparse
 import subprocess
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -24,7 +24,7 @@ def upload():
 def convert():
     # TODO: error handling?
     sys.stdout.flush()
-    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', '/work/flatbuffer_file', '-o', '/work/orc_file', '/work/*'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
+    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', '/work/flatbuffer_file', '-o', '/work/orc_file', '/work/*'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT, shell=True)
     print('[INFO] Finished running conversion')
 
 def download(keys_array):

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -27,7 +27,7 @@ def convert():
     # TODO: error handling?
     sys.stdout.flush()
 
-    process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file'] + glob.glob('*'), timeout=300, universal_newlines=True)
+    process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file'] + glob.glob('*'), timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
 
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -30,9 +30,8 @@ def convert():
     #cmd = 'echo WHAT_IS_GOING_ON'
 
     sys.stdout.flush()
-    process = subprocess.check_output(cmd, shell=True, timeout=300)
-    process.wait()
-    print '[INFO] Finished running conversion, return code: ' + str(process.returncode)
+    process = subprocess.check_output(cmd, shell=True, timeout=300, stderr=subprocess.STDOUT, universal_newlines=True)
+    print '[INFO] Finished running conversion'
 
 def download(keys_array):
     # download stuff

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -4,7 +4,7 @@ import os
 import sys
 import boto3
 import argparse
-import subprocess
+#import subprocess
 
 def cleanup():
     pass
@@ -30,7 +30,9 @@ def convert(keys_array):
 
     # TODO: error handling?
     sys.stdout.flush()
-    process = subprocess.run(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, check=True)
+    #process = subprocess.run(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, check=True)
+    cmd = 'datastore-histogram-tile-writer --time-bucket ' + str(args.time_bucket) + ' --tile ' + str(args.tile_id) + ' -f flatbuffer_file -o orc_file ' + file_list'
+    process = os.system(cmd)
     print('[INFO] Finished running conversion')
 
 def download(keys_array):

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -27,7 +27,7 @@ def convert():
     sys.stdout.flush()
 
     cmd = 'datastore-histogram-tile-writer -v -b ' + str(args.time_bucket) + ' -t ' + str(args.tile_id) + ' -f /work/flatbuffer_file ' + '-o /work/orc_file /work/*'
-    proc = subprocess.run(cmd, timeout=300, universal_newlines=True, stderr=subprocess.STDOUT, shell=True)
+    proc = subprocess.run(cmd, timeout=300, universal_newlines=True, stderr=subprocess.STDOUT, shell=True, check=True)
 
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import sys
 import boto3
 import argparse
 import subprocess
@@ -28,6 +29,7 @@ def convert():
     cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + '--tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file ./*'
     #cmd = 'echo WHAT_IS_GOING_ON'
 
+    sys.stdout.flush()
     process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
     process.wait()
     print '[INFO] Finished running conversion, return code: ' + str(process.returncode)

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -26,10 +26,16 @@ def upload():
     time_path = str(to_time[0]) + '/' + str(to_time[1]) + '/' + str(to_time[2]) + '/' + str(to_time[3]) + str(args.tile_level) + '/'
 
     s3_client = boto3.client('s3')
-    uploads = [str(args.tile_index) + '.fb ', str(args.tile_index) + '.orc']
-    for file in uploads:
+
+    # glob our upload data
+    local_types = ('*.fb', '*.orc')
+    files_grabbed = []
+    for f in local_types:
+        files_grabbed.extend(glob.glob(f))
+
+    for file in files_grabbed:
         data = open(file, 'rb')
-        response = s3_client.put_object(Bucket = args.s3_datastore_bucket, ContentType = 'binary/octet-stream', Body = data, Key = time_path + file)
+        response = s3_client.put_object(Bucket = args.s3_datastore_bucket, ContentType = 'binary/octet-stream', Body = data, Key = time_path + str(args.tile_index))
         data.close()
 
 def convert():

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -30,7 +30,7 @@ def convert(keys_array):
 
     # TODO: error handling?
     sys.stdout.flush()
-    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, check=True)
+    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, cwd='/work', universal_newlines=True, stderr=subprocess.STDOUT)
     print('[INFO] Finished running conversion')
 
 def download(keys_array):

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
 print '[INFO] reporter intput bucket: ' + args.s3_reporter_bucket
 print '[INFO] datastore output bucket: ' + args.s3_datastore_bucket
 print '[INFO] time bucket: ' + str(args.time_bucket)
-print '[INFO] tile: ' + str(args.tile)
+print '[INFO] tile: ' + str(args.tile_id)
 
 # parse our key list
 keys_array = args.s3_reporter_keys.split(',')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -20,7 +20,7 @@ def upload():
     s3_client = boto3.client('s3')
     uploads = glob.glob('*.fb')
     for file in uploads:
-        response = s3_client.upload_file(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream')
+        response = s3_client.upload_file(Bucket = args.s3_datastore_bucket, Key = file)
 
 def convert():
     # TODO: error handling?

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -49,8 +49,7 @@ for key in keys_array:
 # TODO: error handling?
 print '[INFO] running conversion process'
 #call_cmd = '/usr/local/bin/datastore-histogram-tile-writer --time-bucket ' + str(args.time_bucket) + ' --tile ' + str(args.tile_id) + ' -f flatbuffer_file -o orc_file ./*'
-call_cmd = 'touch YAY_IT_WORKED'
-call(call_cmd)
+call('touch YAY_IT_WORKED')
 
 # TODO: upload the result to s3_datastore_bucket
 s3_client = boto3.client('s3')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -32,7 +32,7 @@ def convert(keys_array):
     # TODO: error handling?
     sys.stdout.flush()
 
-    process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, universal_newlines=True)
+    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
 
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -21,10 +21,7 @@ print '[INFO] tile: ' + str(args.tile_id)
 
 # parse our key list
 keys_array = args.s3_reporter_keys.split(',')
-print keys_array
-
-# keep a list of all the files we iterate over to delete later in a bulk operation
-delete_array = []
+#print keys_array
 
 # download stuff
 print '[INFO] downloading data from s3'
@@ -35,11 +32,13 @@ print '[INFO] downloading data from s3'
 # an object of k,v
 client = boto3.client('s3')
 response = client.list_objects_v2(Bucket=args.s3_reporter_bucket)
-print response
 
+delete_array = []
 s3_resource = boto3.resource('s3')
 for key in keys_array:
     object_id = key.rsplit('/', 1)[-1]
+    print '[INFO] Downloading ' + object_id + ' from s3'
+
     s3_resource.Object(args.s3_reporter_bucket, key).download_file(object_id)
     delete_array.append( { 'Key': key } ) 	   
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -5,90 +5,81 @@ import boto3
 import argparse
 import subprocess
 
-# build args
-parser = argparse.ArgumentParser()
-parser.add_argument(
-    's3_reporter_bucket',
-    type=str,
-    help='Bucket (e.g. reporter-drop-prod) in which the data we wish to process is located'
-    )
-parser.add_argument(
-    's3_datastore_bucket',
-    type=str,
-    help='Bucket (e.g. datastore-output-prod) into which we will place transformed data'
-    )
-parser.add_argument(
-    's3_reporter_keys',
-    type=str,
-    help='S3 object keys which we will operate on, found in the s3_reporter_bucket'
-    )
-parser.add_argument(
-    'time_bucket',
-    type=int,
-    help='The time bucket'
-    )
-parser.add_argument(
-    'tile_id',
-    type=int,
-    help='The tile ID'
-    )
-args = parser.parse_args()
+def cleanup():
+    # delete the original keys from the s3_reporter_bucket
+    #print '[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket
+    #response = s3_client.delete_objects(
+    #    Bucket = args.s3_reporter_bucket,
+    #    Delete = { 'Objects': delete_array }
+    #    )
 
-print '[INFO] reporter intput bucket: ' + args.s3_reporter_bucket
-print '[INFO] datastore output bucket: ' + args.s3_datastore_bucket
-print '[INFO] time bucket: ' + str(args.time_bucket)
-print '[INFO] tile: ' + str(args.tile_id)
+def upload():
+    s3_client = boto3.client('s3')
+    uploads = ['flatbuffer_file', 'orc_file']
+    for file in uploads:
+        response = s3_client.put_object(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream')
 
-# parse our key list
-keys_array = args.s3_reporter_keys.split(',')
+def convert():
+    # run our java thingy: the Docker container workdir will have already put us
+    #   in the right place to, ummm, do work
 
-# download stuff
-print '[INFO] downloading data from s3'
+    # TODO: error handling?
+    #cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + '--tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file ./*'
+    cmd = 'echo WHAT_IS_GOING_ON'
 
-# this obviously isn't gonna really work... we'll
-# need to maintain the S3 path as a local filesystem
-# path to preserve everything... or preserve them in
-# an object of k,v
-client = boto3.client('s3')
-response = client.list_objects_v2(Bucket=args.s3_reporter_bucket)
+    process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+    process.wait()
+    print '[INFO] Finished running conversion, return code: ' + process.returncode
 
-delete_array = []
-s3_resource = boto3.resource('s3')
-for key in keys_array:
-    object_id = key.rsplit('/', 1)[-1]
-    print '[INFO] Downloading ' + object_id + ' from s3'
+def download(keys_array):
+    # download stuff
+    print '[INFO] downloading data from s3'
 
-    s3_resource.Object(args.s3_reporter_bucket, key).download_file(object_id)
-    delete_array.append( { 'Key': key } ) 	   
+    # this obviously isn't gonna really work... we'll
+    # need to maintain the S3 path as a local filesystem
+    # path to preserve everything... or preserve them in
+    # an object of k,v
+    client = boto3.client('s3')
+    response = client.list_objects_v2(Bucket=args.s3_reporter_bucket)
 
-# run our java thingy: the Docker container workdir will have already put us
-#   in the right place to, ummm, do work
+    delete_array = []
+    s3_resource = boto3.resource('s3')
+    for key in keys_array:
+        object_id = key.rsplit('/', 1)[-1]
+        print '[INFO] Downloading ' + object_id + ' from s3'
 
-# TODO: error handling?
-print '[INFO] running conversion process'
-#cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + '--tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file ./*'
-cmd = 'echo WHAT_IS_GOING_ON'
+        s3_resource.Object(args.s3_reporter_bucket, key).download_file(object_id)
+        delete_array.append( { 'Key': key } )
 
-process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
-process.wait()
-print '[INFO] Finished running conversion, return code: ' + process.returncode
+if __name__ == "__main__":
+    # build args
+    parser = argparse.ArgumentParser()
+    parser.add_argument('s3_reporter_bucket', type=str,help='Bucket (e.g. reporter-drop-prod) in which the data we wish to process is located')
+    parser.add_argument('s3_datastore_bucket', type=str, help='Bucket (e.g. datastore-output-prod) into which we will place transformed data')
+    parser.add_argument('s3_reporter_keys', type=str, help='S3 object keys which we will operate on, found in the s3_reporter_bucket'
+    parser.add_argument('time_bucket', type=int, help='The time bucket')
+    parser.add_argument('tile_id', type=int, help='The tile ID')
+    args = parser.parse_args()
 
-# TODO: upload the result to s3_datastore_bucket
-s3_client = boto3.client('s3')
+    print '[INFO] reporter intput bucket: ' + args.s3_reporter_bucket
+    print '[INFO] datastore output bucket: ' + args.s3_datastore_bucket
+    print '[INFO] time bucket: ' + str(args.time_bucket)
+    print '[INFO] tile: ' + str(args.tile_id)
 
-uploads = ['flatbuffer_file', 'orc_file']
-for file in uploads:
-    response = s3_client.put_object(
-        Bucket = args.s3_datastore_bucket,
-        Key = file,
-        ContentType = 'binary/octet-stream'
-        )
+    # download stuff
+    print '[INFO] downloading data from s3'
+    download(args.s3_reporter_keys.split(','))
 
-# delete the original keys from the s3_reporter_bucket
-#print '[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket
-#response = s3_client.delete_objects(
-#    Bucket = args.s3_reporter_bucket,
-#    Delete = { 'Objects': delete_array }
-#    )
+    # convert stuff
+    print '[INFO] running conversion process'
+    convert()
 
-print '[INFO] run complete'
+    # TODO: upload the result to s3_datastore_bucket
+    print '[INFO] uploading resulting files'
+    upload()
+    
+    # TODO: cleanup stuff
+    print '[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket
+    cleanup()
+
+    print '[INFO] run complete'

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -32,7 +32,8 @@ def convert(keys_array):
     # TODO: error handling?
     sys.stdout.flush()
 
-    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
+    #process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
+    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', 'opentraffic.2c45aa7a-9171-4e4a-9ddc-f6128293450f'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
 
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -71,7 +71,7 @@ cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_buck
 
 process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
 process.wait()
-print '[INFO] Finished running conversion, return code: ' + process.returncode
+print '[INFO] Finished running conversion, return code: ' + str(process.returncode)
 
 # TODO: upload the result to s3_datastore_bucket
 s3_client = boto3.client('s3')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -56,7 +56,7 @@ uploads = ['flatbuffer_file', 'orc_file']
 for file in uploads:
     response = s3_client.put_object(
         Bucket = args.s3_datastore_bucket,
-        Key = file
+        Key = file,
         ContentType = 'binary/octet-stream'
         )
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import glob
 import boto3
 import signal
 import argparse
@@ -22,18 +23,11 @@ def upload():
     for file in uploads:
         response = s3_client.put_object(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream')
 
-def convert(keys_array):
-    id_array = []
-    for key in keys_array:
-        id_array.append(key.rsplit('/', 1)[-1])
-
-    file_list = ' '.join(id_array)
-
+def convert():
     # TODO: error handling?
     sys.stdout.flush()
 
-    #process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
-    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', 'opentraffic.2c45aa7a-9171-4e4a-9ddc-f6128293450f'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
+    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file'] + glob.glob('*'), timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
 
     print('[INFO] Finished running conversion')
 
@@ -75,7 +69,7 @@ if __name__ == "__main__":
 
     # convert stuff
     print('[INFO] running conversion process')
-    convert(args.s3_reporter_keys.split(','))
+    convert()
 
     # TODO: upload the result to s3_datastore_bucket
     print('[INFO] uploading resulting files')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -48,7 +48,6 @@ for key in keys_array:
 
 # TODO: error handling?
 print '[INFO] running conversion process'
-#call_cmd = '/usr/local/bin/datastore-histogram-tile-writer --time-bucket ' + str(args.time_bucket) + ' --tile ' + str(args.tile_id) + ' -f flatbuffer_file -o orc_file ./*'
 #call(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', './*'])
 call(['touch', 'YAY_IT_WORKED'])
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -21,12 +21,12 @@ def upload():
     for file in uploads:
         response = s3_client.put_object(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream')
 
-def convert():
-    # run our java thingy: the Docker container workdir will have already put us
-    #   in the right place to, ummm, do work
+def convert(keys_array):
+    file_list = ' '.join(keys_array)
 
     # TODO: error handling?
-    cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + '--tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file ./*'
+    cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + '--tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file' + ' ' + file_list
+    print('[INFO] Running the following conversion cmd: ' + cmd)
     #cmd = 'echo WHAT_IS_GOING_ON'
 
     sys.stdout.flush()
@@ -74,7 +74,7 @@ if __name__ == "__main__":
 
     # convert stuff
     print('[INFO] running conversion process')
-    convert()
+    convert(args.s3_reporter_keys.split(','))
 
     # TODO: upload the result to s3_datastore_bucket
     print('[INFO] uploading resulting files')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -24,7 +24,9 @@ def upload():
 def convert():
     # TODO: error handling?
     sys.stdout.flush()
-    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', '/work/flatbuffer_file', '-o', '/work/orc_file', '/work/*'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT, shell=True)
+    #process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', '/work/flatbuffer_file', '-o', '/work/orc_file', '/work/*'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
+    cmd = 'datastore-histogram-tile-writer' + ' ' + '-b' + ' ' + str(args.time_bucket) + ' ' + '-t' + ' ' + (args.tile_id) + ' ' + '-v' + ' ' + '-f' + ' ' + '/work/flatbuffer_file' + ' ' + '-o' + ' ' + '/work/orc_file' + ' ' + '/work/*'
+    process = subprocess.run(cmd, timeout=300, universal_newlines=True, stderr=subprocess.STDOUT, shell=True)
     print('[INFO] Finished running conversion')
 
 def download(keys_array):

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -9,7 +9,7 @@ import subprocess
 def cleanup():
     pass
     # delete the original keys from the s3_reporter_bucket
-    #print '[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket
+    #print('[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket)
     #response = s3_client.delete_objects(
     #    Bucket = args.s3_reporter_bucket,
     #    Delete = { 'Objects': delete_array }
@@ -31,11 +31,11 @@ def convert():
 
     sys.stdout.flush()
     process = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, timeout=300, universal_newlines=True)
-    print '[INFO] Finished running conversion'
+    print('[INFO] Finished running conversion')
 
 def download(keys_array):
     # download stuff
-    print '[INFO] downloading data from s3'
+    print('[INFO] downloading data from s3')
 
     # this obviously isn't gonna really work... we'll
     # need to maintain the S3 path as a local filesystem
@@ -48,7 +48,7 @@ def download(keys_array):
     s3_resource = boto3.resource('s3')
     for key in keys_array:
         object_id = key.rsplit('/', 1)[-1]
-        print '[INFO] Downloading ' + object_id + ' from s3'
+        print('[INFO] Downloading ' + object_id + ' from s3')
 
         s3_resource.Object(args.s3_reporter_bucket, key).download_file(object_id)
         delete_array.append( { 'Key': key } )
@@ -63,25 +63,25 @@ if __name__ == "__main__":
     parser.add_argument('tile_id', type=int, help='The tile ID')
     args = parser.parse_args()
 
-    print '[INFO] reporter intput bucket: ' + args.s3_reporter_bucket
-    print '[INFO] datastore output bucket: ' + args.s3_datastore_bucket
-    print '[INFO] time bucket: ' + str(args.time_bucket)
-    print '[INFO] tile: ' + str(args.tile_id)
+    print('[INFO] reporter intput bucket: ' + args.s3_reporter_bucket)
+    print('[INFO] datastore output bucket: ' + args.s3_datastore_bucket)
+    print('[INFO] time bucket: ' + str(args.time_bucket))
+    print('[INFO] tile: ' + str(args.tile_id))
 
     # download stuff
-    print '[INFO] downloading data from s3'
+    print('[INFO] downloading data from s3')
     download(args.s3_reporter_keys.split(','))
 
     # convert stuff
-    print '[INFO] running conversion process'
+    print('[INFO] running conversion process')
     convert()
 
     # TODO: upload the result to s3_datastore_bucket
-    print '[INFO] uploading resulting files'
+    print('[INFO] uploading resulting files')
     upload()
     
     # TODO: cleanup stuff
-    print '[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket
+    print('[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket)
     cleanup()
 
-    print '[INFO] run complete'
+    print('[INFO] run complete')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -30,7 +30,7 @@ def convert(keys_array):
 
     # TODO: error handling?
     sys.stdout.flush()
-    process = subprocess.run(['datastore-histogram-tile-writer', '-v', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, check=True)
+    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, check=True)
     print('[INFO] Finished running conversion')
 
 def download(keys_array):

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -33,7 +33,7 @@ def convert(keys_array):
     sys.stdout.flush()
 
     #process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
-    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', 'opentraffic.2c45aa7a-9171-4e4a-9ddc-f6128293450f'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
+    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file', '/work/opentraffic.2c45aa7a-9171-4e4a-9ddc-f6128293450f'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
 
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -49,7 +49,8 @@ for key in keys_array:
 # TODO: error handling?
 print '[INFO] running conversion process'
 #call_cmd = '/usr/local/bin/datastore-histogram-tile-writer --time-bucket ' + str(args.time_bucket) + ' --tile ' + str(args.tile_id) + ' -f flatbuffer_file -o orc_file ./*'
-call('touch YAY_IT_WORKED')
+#call(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', './*'])
+call(['touch', 'YAY_IT_WORKED'])
 
 # TODO: upload the result to s3_datastore_bucket
 s3_client = boto3.client('s3')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -24,9 +24,12 @@ def upload():
 def convert():
     # TODO: error handling?
     sys.stdout.flush()
+    sys.stderr.flush()
     #process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', '/work/flatbuffer_file', '-o', '/work/orc_file', '/work/*'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
-    cmd = 'datastore-histogram-tile-writer' + ' ' + '-b' + ' ' + str(args.time_bucket) + ' ' + '-t' + ' ' + (args.tile_id) + ' ' + '-v' + ' ' + '-f' + ' ' + '/work/flatbuffer_file' + ' ' + '-o' + ' ' + '/work/orc_file' + ' ' + '/work/*'
+    cmd = 'datastore-histogram-tile-writer -b ' + str(args.time_bucket) + ' -t ' str(args.tile_id) + ' -v ' + '-f ' + '/work/flatbuffer_file ' + '-o ' + '/work/orc_file ' + '/work/*'
     process = subprocess.run(cmd, timeout=300, universal_newlines=True, stderr=subprocess.STDOUT, shell=True)
+    sys.stdout.flush()
+    sys.stderr.flush()
     print('[INFO] Finished running conversion')
 
 def download(keys_array):

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('s3_reporter_bucket', type=str,help='Bucket (e.g. reporter-drop-prod) in which the data we wish to process is located')
     parser.add_argument('s3_datastore_bucket', type=str, help='Bucket (e.g. datastore-output-prod) into which we will place transformed data')
-    parser.add_argument('s3_reporter_keys', type=str, help='S3 object keys which we will operate on, found in the s3_reporter_bucket'
+    parser.add_argument('s3_reporter_keys', type=str, help='S3 object keys which we will operate on, found in the s3_reporter_bucket')
     parser.add_argument('time_bucket', type=int, help='The time bucket')
     parser.add_argument('tile_id', type=int, help='The tile ID')
     args = parser.parse_args()

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -26,7 +26,7 @@ def convert():
     sys.stdout.flush()
     sys.stderr.flush()
     #process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', '/work/flatbuffer_file', '-o', '/work/orc_file', '/work/*'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
-    cmd = 'datastore-histogram-tile-writer -b ' + str(args.time_bucket) + ' -t ' str(args.tile_id) + ' -v ' + '-f ' + '/work/flatbuffer_file ' + '-o ' + '/work/orc_file ' + '/work/*'
+    cmd = 'datastore-histogram-tile-writer -b ' + str(args.time_bucket) + ' -t ' + str(args.tile_id) + ' -v ' + '-f ' + '/work/flatbuffer_file ' + '-o ' + '/work/orc_file ' + '/work/*'
     process = subprocess.run(cmd, timeout=300, universal_newlines=True, stderr=subprocess.STDOUT, shell=True)
     sys.stdout.flush()
     sys.stderr.flush()

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import boto3
+import signal
 import argparse
 import subprocess
 
@@ -24,12 +25,10 @@ def upload():
 def convert():
     # TODO: error handling?
     sys.stdout.flush()
-    sys.stderr.flush()
-    #process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', '/work/flatbuffer_file', '-o', '/work/orc_file', '/work/*'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
-    cmd = 'datastore-histogram-tile-writer -b ' + str(args.time_bucket) + ' -t ' + str(args.tile_id) + ' -v ' + '-f ' + '/work/flatbuffer_file ' + '-o ' + '/work/orc_file ' + '/work/*'
-    process = subprocess.run(cmd, timeout=300, universal_newlines=True, stderr=subprocess.STDOUT, shell=True)
-    sys.stdout.flush()
-    sys.stderr.flush()
+
+    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', '/work/flatbuffer_file', '-o', '/work/orc_file', '/work/*'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
+    process.terminate()
+
     print('[INFO] Finished running conversion')
 
 def download(keys_array):

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -3,7 +3,7 @@
 import os
 import boto3
 import argparse
-from subprocess import call
+import subprocess
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -48,8 +48,10 @@ for key in keys_array:
 # TODO: error handling?
 print '[INFO] running conversion process'
 cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + '--tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file ./*'
-call(cmd, shell = True)
-#call(['touch', 'YAY_IT_WORKS'])
+
+process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+process.wait()
+print '[INFO] Finished running conversion, return code: ' + process.returncode
 
 # TODO: upload the result to s3_datastore_bucket
 s3_client = boto3.client('s3')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -48,7 +48,8 @@ for key in keys_array:
 
 # TODO: error handling?
 print '[INFO] running conversion process'
-call_cmd = '/usr/local/bin/datastore-histogram-tile-writer --time-bucket ' + str(args.time_bucket) + ' --tile ' + str(args.tile_id) + ' -f flatbuffer_file -o orc_file ./*'
+#call_cmd = '/usr/local/bin/datastore-histogram-tile-writer --time-bucket ' + str(args.time_bucket) + ' --tile ' + str(args.tile_id) + ' -f flatbuffer_file -o orc_file ./*'
+call_cmd = 'touch YAY_IT_WORKED'
 call(call_cmd)
 
 # TODO: upload the result to s3_datastore_bucket

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
 
     # convert stuff
     print('[INFO] running conversion process')
-    convert(args.s3_reporter_keys.split(','))
+    convert()
 
     # TODO: upload the result to s3_datastore_bucket
     print('[INFO] uploading resulting files')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -30,7 +30,7 @@ def convert(keys_array):
 
     # TODO: error handling?
     sys.stdout.flush()
-    process = subprocess.check_output(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], stderr=subprocess.STDOUT, timeout=300, universal_newlines=True)
+    process = subprocess.run(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], timeout=300, check=True)
     print('[INFO] Finished running conversion')
 
 def download(keys_array):

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -71,7 +71,7 @@ def download(keys_array):
 if __name__ == "__main__":
     # build args
     parser = argparse.ArgumentParser()
-    parser.add_argument('s3_reporter_bucket', type=str,help='Bucket (e.g. reporter-drop-prod) in which the data we wish to process is located')
+    parser.add_argument('s3_reporter_bucket', type=str,help='Bucket (e.g. reporter-work-prod) in which the data we wish to process is located')
     parser.add_argument('s3_datastore_bucket', type=str, help='Bucket (e.g. datastore-output-prod) into which we will place transformed data')
     parser.add_argument('s3_reporter_keys', type=str, help='S3 object keys which we will operate on, found in the s3_reporter_bucket')
     parser.add_argument('time_bucket', type=int, help='The time bucket')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -21,6 +21,7 @@ print '[INFO] tile: ' + str(args.tile_id)
 
 # parse our key list
 keys_array = args.s3_reporter_keys.split(',')
+print keys_array
 
 # keep a list of all the files we iterate over to delete later in a bulk operation
 delete_array = []
@@ -32,9 +33,12 @@ print '[INFO] downloading data from s3'
 # need to maintain the S3 path as a local filesystem
 # path to preserve everything... or preserve them in
 # an object of k,v
+client = boto3.client('s3')
+response = client.list_objects_v2(Bucket=args.s3_reporter_bucket)
+print response
+
 s3_resource = boto3.resource('s3')
 for key in keys_array:
-    print '[INFO] Downloading ' + key
     object_id = key.rsplit('/', 1)[-1]
     s3_resource.Object(args.s3_reporter_bucket, key).download_file(object_id)
     delete_array.append( { 'Key': key } ) 	   
@@ -44,7 +48,8 @@ for key in keys_array:
 
 # TODO: error handling?
 print '[INFO] running conversion process'
-call('datastore-histogram-tile-writer --time-bucket time_bucket --tile tile_id -f flatbuffer_file -o orc_file ./*')
+call_cmd = '/usr/local/bin/datastore-histogram-tile-writer --time-bucket ' + str(args.time_bucket) + ' --tile ' + str(args.tile_id) + ' -f flatbuffer_file -o orc_file ./*'
+call(call_cmd)
 
 # TODO: upload the result to s3_datastore_bucket
 s3_client = boto3.client('s3')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -22,6 +22,7 @@ def upload():
     for file in uploads:
         data = open(file, 'rb')
         response = s3_client.put_object(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream', Body = data)
+        data.close()
 
 def convert():
     # TODO: error handling?

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3 -u
 
 import os
-import sys
 import glob
 import boto3
 import signal
@@ -25,8 +24,6 @@ def upload():
 
 def convert():
     # TODO: error handling?
-    sys.stdout.flush()
-
     process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file'] + glob.glob('*'), timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
 
     print('[INFO] Finished running conversion')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -39,9 +39,6 @@ def convert(keys_array):
     print('[INFO] Finished running conversion')
 
 def download(keys_array):
-    # download stuff
-    print('[INFO] downloading data from s3')
-
     # this obviously isn't gonna really work... we'll
     # need to maintain the S3 path as a local filesystem
     # path to preserve everything... or preserve them in

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -47,7 +47,7 @@ for key in keys_array:
 
 # TODO: error handling?
 print '[INFO] running conversion process'
-cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + ' --tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file ./*'
+cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + '--tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file ./*'
 call(cmd, shell = True)
 #call(['touch', 'YAY_IT_WORKS'])
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -27,7 +27,7 @@ def convert():
     # TODO: error handling?
     sys.stdout.flush()
 
-    process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file'] + glob.glob('*'), timeout=60, universal_newlines=True)
+    process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file'] + glob.glob('*'), timeout=300, universal_newlines=True)
 
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -47,7 +47,8 @@ for key in keys_array:
 
 # TODO: error handling?
 print '[INFO] running conversion process'
-call(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', './*'])
+#call(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', './*'])
+call(['touch', 'YAY_IT_WORKS'])
 
 # TODO: upload the result to s3_datastore_bucket
 s3_client = boto3.client('s3')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -47,8 +47,9 @@ for key in keys_array:
 
 # TODO: error handling?
 print '[INFO] running conversion process'
-#call(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', './*'])
-call(['touch', 'YAY_IT_WORKS'])
+cmd = 'datastore-histogram-tile-writer --time-bucket' + str(args.time_bucket) + '--tile' + str(args.tile_id) + '-f flatbuffer_file -o orc_file ./*'
+call(cmd, shell = True)
+#call(['touch', 'YAY_IT_WORKS'])
 
 # TODO: upload the result to s3_datastore_bucket
 s3_client = boto3.client('s3')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -5,14 +5,34 @@ import boto3
 import argparse
 import subprocess
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument('s3_reporter_bucket', type=str, help='Bucket (e.g. reporter-drop-prod) in which the data we wish to process is located')
-    parser.add_argument('s3_datastore_bucket', type=str, help='Bucket (e.g. datastore-output-prod) into which we will place transformed data')
-    parser.add_argument('s3_reporter_keys', type=str, help='S3 object keys which we will operate on, found in the s3_reporter_bucket')
-    parser.add_argument('time_bucket', type=int, help='The time bucket')
-    parser.add_argument('tile_id', type=int, help='The tile ID')
-    args = parser.parse_args()
+# build args
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    's3_reporter_bucket',
+    type=str,
+    help='Bucket (e.g. reporter-drop-prod) in which the data we wish to process is located'
+    )
+parser.add_argument(
+    's3_datastore_bucket',
+    type=str,
+    help='Bucket (e.g. datastore-output-prod) into which we will place transformed data'
+    )
+parser.add_argument(
+    's3_reporter_keys',
+    type=str,
+    help='S3 object keys which we will operate on, found in the s3_reporter_bucket'
+    )
+parser.add_argument(
+    'time_bucket',
+    type=int,
+    help='The time bucket'
+    )
+parser.add_argument(
+    'tile_id',
+    type=int,
+    help='The tile ID'
+    )
+args = parser.parse_args()
 
 print '[INFO] reporter intput bucket: ' + args.s3_reporter_bucket
 print '[INFO] datastore output bucket: ' + args.s3_datastore_bucket
@@ -21,7 +41,6 @@ print '[INFO] tile: ' + str(args.tile_id)
 
 # parse our key list
 keys_array = args.s3_reporter_keys.split(',')
-#print keys_array
 
 # download stuff
 print '[INFO] downloading data from s3'

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -9,14 +9,18 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('s3_reporter_bucket', type=str, help='Bucket (e.g. reporter-drop-prod) in which the data we wish to process is located')
     parser.add_argument('s3_datastore_bucket', type=str, help='Bucket (e.g. datastore-output-prod) into which we will place transformed data')
-    parser.add_argument('reporter_s3_keys', type=str, help='S3 object keys which we will operate on, found in the s3_reporter_bucket')
+    parser.add_argument('s3_reporter_keys', type=str, help='S3 object keys which we will operate on, found in the s3_reporter_bucket')
+    parser.add_argument('time_bucket', type=str, help='The time bucket')
+    parser.add_argument('tile_id', type=str, help='The tile ID')
     args = parser.parse_args()
 
 print '[INFO] reporter intput bucket: ' + args.s3_reporter_bucket
 print '[INFO] datastore output bucket: ' + args.s3_datastore_bucket
+print '[INFO] time bucket: ' + args.time_bucket
+print '[INFO] tile: ' + args.tile
 
 # parse our key list
-keys_array = args.reporter_s3_keys.split(',')
+keys_array = args.s3_reporter_keys.split(',')
 
 # keep a list of all the files we iterate over to delete later in a bulk operation
 delete_array = []
@@ -35,7 +39,7 @@ for key in keys_array:
 
 # TODO: error handling?
 print '[INFO] running conversion process'
-call('datastore-histogram-tile-writer -f flatbuffer_file -o orc_file ./*')
+call('datastore-histogram-tile-writer --time-bucket time_bucket --tile tile_id -f flatbuffer_file -o orc_file ./*')
 
 # TODO: upload the result to s3_datastore_bucket
 s3_client = boto3.client('s3')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -28,9 +28,6 @@ def convert():
 
     cmd = 'datastore-histogram-tile-writer -v -b ' + str(args.time_bucket) + ' -t ' + str(args.tile_id) + ' -f /work/flatbuffer_file ' + '-o /work/orc_file /work/*'
     proc = subprocess.run(cmd, timeout=300, universal_newlines=True, stderr=subprocess.STDOUT, shell=True)
-    out,err = proc.communicate()
-    print(out)
-    print(err)
 
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -41,10 +41,10 @@ call('datastore-histogram-tile-writer -f flatbuffer_file -o orc_file ./*')
 s3_client = boto3.client('s3')
 for upload_file in os.listdir('.'):
     response = s3_client.put_object(
-                Bucket = args.s3_datastore_bucket,
-                Key = upload_file,
-                ContentType = 'binary/octet-stream'
-                )
+        Bucket = args.s3_datastore_bucket,
+        Key = upload_file,
+        ContentType = 'binary/octet-stream'
+        )
 
 # delete the original keys from the s3_reporter_bucket
 print '[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -30,7 +30,7 @@ def convert():
     #cmd = 'echo WHAT_IS_GOING_ON'
 
     sys.stdout.flush()
-    process = subprocess.run(cmd, shell=True, timeout=300, check=True, stdout=PIPE, stderr=PIPE)
+    process = subprocess.check_output(cmd, shell=True, timeout=300)
     process.wait()
     print '[INFO] Finished running conversion, return code: ' + str(process.returncode)
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -20,7 +20,7 @@ def upload():
     s3_client = boto3.client('s3')
     uploads = glob.glob('*.fb')
     for file in uploads:
-        response = s3_client.put_object(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream')
+        response = s3_client.upload_file(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream')
 
 def convert():
     # TODO: error handling?

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -26,7 +26,7 @@ def upload():
     for file_extension in uploads:
         # ex path key: year/month/day/hour/tile_level/tile_index.fb
         to_time = time.gmtime(args.time_bucket * 3600)
-        time_key = str(to_time[0]) + '/' + str(to_time[1]) + '/' + str(to_time[2]) + '/' + str(to_time[3]) + str(args.tile_level) + '/' + str(args.tile_index) + file_extension
+        time_key = str(to_time[0]) + '/' + str(to_time[1]) + '/' + str(to_time[2]) + '/' + str(to_time[3]) + '/' + str(args.tile_level) + '/' + str(args.tile_index) + file_extension
 
         data = open(str(args.tile_index) + file_extension, 'rb')
         response = s3_client.put_object(Bucket = args.s3_datastore_bucket, ContentType = 'binary/octet-stream', Body = data, Key = time_key)

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -27,7 +27,7 @@ def convert():
     sys.stdout.flush()
 
     cmd = 'datastore-histogram-tile-writer -v -b ' + str(args.time_bucket) + ' -t ' + str(args.tile_id) + ' -f /work/flatbuffer_file ' + '-o /work/orc_file /work/*'
-    proc = subprocess.run(cmd, timeout=300, universal_newlines=True, stderr=subprocess.STDOUT, shell=True, check=True)
+    proc = subprocess.check_output(cmd, timeout=300, universal_newlines=True, shell=True)
 
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -20,7 +20,7 @@ def upload():
     s3_client = boto3.client('s3')
     uploads = glob.glob('*.fb')
     for file in uploads:
-        response = s3_client.upload_file(Bucket = args.s3_datastore_bucket, Key = file)
+        response = s3_client.upload_file(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream')
 
 def convert():
     # TODO: error handling?

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -30,7 +30,7 @@ def convert():
     #cmd = 'echo WHAT_IS_GOING_ON'
 
     sys.stdout.flush()
-    process = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, universal_newlines=True)
+    process = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, timeout=300, universal_newlines=True)
     print '[INFO] Finished running conversion'
 
 def download(keys_array):

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -10,14 +10,14 @@ if __name__ == '__main__':
     parser.add_argument('s3_reporter_bucket', type=str, help='Bucket (e.g. reporter-drop-prod) in which the data we wish to process is located')
     parser.add_argument('s3_datastore_bucket', type=str, help='Bucket (e.g. datastore-output-prod) into which we will place transformed data')
     parser.add_argument('s3_reporter_keys', type=str, help='S3 object keys which we will operate on, found in the s3_reporter_bucket')
-    parser.add_argument('time_bucket', type=str, help='The time bucket')
-    parser.add_argument('tile_id', type=str, help='The tile ID')
+    parser.add_argument('time_bucket', type=int, help='The time bucket')
+    parser.add_argument('tile_id', type=int, help='The tile ID')
     args = parser.parse_args()
 
 print '[INFO] reporter intput bucket: ' + args.s3_reporter_bucket
 print '[INFO] datastore output bucket: ' + args.s3_datastore_bucket
-print '[INFO] time bucket: ' + args.time_bucket
-print '[INFO] tile: ' + args.tile
+print '[INFO] time bucket: ' + str(args.time_bucket)
+print '[INFO] tile: ' + str(args.tile)
 
 # parse our key list
 keys_array = args.s3_reporter_keys.split(',')
@@ -28,6 +28,10 @@ delete_array = []
 # download stuff
 print '[INFO] downloading data from s3'
 
+# this obviously isn't gonna really work... we'll
+# need to maintain the S3 path as a local filesystem
+# path to preserve everything... or preserve them in
+# an object of k,v
 s3_resource = boto3.resource('s3')
 for key in keys_array:
     object_id = key.rsplit('/', 1)[-1]

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -26,8 +26,11 @@ def convert():
     # TODO: error handling?
     sys.stdout.flush()
 
-    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', '/work/flatbuffer_file', '-o', '/work/orc_file', '/work/*'], timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
-    process.terminate()
+    cmd = 'datastore-histogram-tile-writer -v -b ' + str(args.time_bucket) + '-t ' + str(args.tile_id) + ' -f /work/flatbuffer_file ' + '-o /work/orc_file /work/*'
+    proc = subprocess.run(cmd, timeout=300, universal_newlines=True, stderr=subprocess.STDOUT, shell=True)
+    out,err = proc.communicate()
+    print out
+    print err
 
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -47,7 +47,8 @@ for key in keys_array:
 
 # TODO: error handling?
 print '[INFO] running conversion process'
-cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + '--tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file ./*'
+#cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + '--tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file ./*'
+cmd = 'echo WHAT_IS_GOING_ON'
 
 process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
 process.wait()

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -34,6 +34,7 @@ print '[INFO] downloading data from s3'
 # an object of k,v
 s3_resource = boto3.resource('s3')
 for key in keys_array:
+    print '[INFO] Downloading ' + key
     object_id = key.rsplit('/', 1)[-1]
     s3_resource.Object(args.s3_reporter_bucket, key).download_file(object_id)
     delete_array.append( { 'Key': key } ) 	   

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -60,6 +60,9 @@ for upload_file in os.listdir('.'):
         ContentType = 'binary/octet-stream'
         )
 
+# cleanup
+# TODO: have to remove local output when done
+
 # delete the original keys from the s3_reporter_bucket
 print '[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket
 response = s3_client.delete_objects(

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -6,6 +6,7 @@ import argparse
 import subprocess
 
 def cleanup():
+    pass
     # delete the original keys from the s3_reporter_bucket
     #print '[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket
     #response = s3_client.delete_objects(

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -66,8 +66,8 @@ for key in keys_array:
 
 # TODO: error handling?
 print '[INFO] running conversion process'
-#cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + '--tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file ./*'
-cmd = 'echo WHAT_IS_GOING_ON'
+cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + '--tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file ./*'
+#cmd = 'echo WHAT_IS_GOING_ON'
 
 process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
 process.wait()

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -30,7 +30,7 @@ def convert():
     #cmd = 'echo WHAT_IS_GOING_ON'
 
     sys.stdout.flush()
-    process = subprocess.check_output(cmd, shell=True, timeout=300, stderr=subprocess.STDOUT, universal_newlines=True)
+    process = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, universal_newlines=True)
     print '[INFO] Finished running conversion'
 
 def download(keys_array):

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -21,11 +21,11 @@ def cleanup(delete_array):
 def upload():
     print('[INFO] uploading data')
     s3_client = boto3.client('s3')
+    to_time = time.gmtime(args.time_bucket * 3600)
 
     uploads = ['.fb', '.orc']
     for file_extension in uploads:
-        # ex path key: year/month/day/hour/tile_level/tile_index.fb
-        to_time = time.gmtime(args.time_bucket * 3600)
+        # path key: year/month/day/hour/tile_level/tile_index.fb
         time_key = str(to_time[0]) + '/' + str(to_time[1]) + '/' + str(to_time[2]) + '/' + str(to_time[3]) + '/' + str(args.tile_level) + '/' + str(args.tile_index) + file_extension
 
         data = open(str(args.tile_index) + file_extension, 'rb')
@@ -91,6 +91,6 @@ if __name__ == "__main__":
     delete_list = download(args.s3_reporter_keys.split(','))
     convert()
     upload()
-    cleanup(delete_list)
+    cleanup(delete_list) # TODO: untested
 
     print('[INFO] run complete')

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -48,26 +48,24 @@ for key in keys_array:
 
 # TODO: error handling?
 print '[INFO] running conversion process'
-#call(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', './*'])
-call(['touch', 'YAY_IT_WORKED'])
+call(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', './*'])
 
 # TODO: upload the result to s3_datastore_bucket
 s3_client = boto3.client('s3')
-for upload_file in os.listdir('.'):
+
+uploads = ['flatbuffer_file', 'orc_file']
+for file in uploads:
     response = s3_client.put_object(
         Bucket = args.s3_datastore_bucket,
-        Key = upload_file,
+        Key = file
         ContentType = 'binary/octet-stream'
         )
 
-    # remove the local file after successful upload
-    os.remove(upload_file)
-
 # delete the original keys from the s3_reporter_bucket
-print '[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket
-response = s3_client.delete_objects(
-    Bucket = args.s3_reporter_bucket,
-    Delete = { 'Objects': delete_array }
-    )
+#print '[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket
+#response = s3_client.delete_objects(
+#    Bucket = args.s3_reporter_bucket,
+#    Delete = { 'Objects': delete_array }
+#    )
 
 print '[INFO] run complete'

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -22,15 +22,20 @@ def upload():
         response = s3_client.put_object(Bucket = args.s3_datastore_bucket, Key = file, ContentType = 'binary/octet-stream')
 
 def convert(keys_array):
-    file_list = ' '.join(keys_array)
+    id_array = []
+    for key in keys_array:
+        id_array.append(key.rsplit('/', 1)[-1])
+
+    file_list = ' '.join(id_array)
 
     # TODO: error handling?
-    cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + '--tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file' + ' ' + file_list
-    print('[INFO] Running the following conversion cmd: ' + cmd)
+    #cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + '--tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file' + ' ' + file_list
+    #print('[INFO] Running the following conversion cmd: ' + cmd)
     #cmd = 'echo WHAT_IS_GOING_ON'
 
     sys.stdout.flush()
-    process = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, timeout=300, universal_newlines=True)
+    #process = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, timeout=300, universal_newlines=True)
+    process = subprocess.check_output(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], stderr=subprocess.STDOUT, timeout=300, universal_newlines=True)
     print('[INFO] Finished running conversion')
 
 def download(keys_array):

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -27,7 +27,7 @@ def convert():
     # TODO: error handling?
     sys.stdout.flush()
 
-    process = subprocess.run(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file'] + glob.glob('*'), timeout=300, universal_newlines=True, stderr=subprocess.STDOUT)
+    process = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(args.time_bucket), '-t', str(args.tile_id), '-v', '-f', 'flatbuffer_file', '-o', 'orc_file'] + glob.glob('*'), timeout=60, universal_newlines=True)
 
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -60,8 +60,8 @@ for upload_file in os.listdir('.'):
         ContentType = 'binary/octet-stream'
         )
 
-# cleanup
-# TODO: have to remove local output when done
+    # remove the local file after successful upload
+    os.remove(upload_file)
 
 # delete the original keys from the s3_reporter_bucket
 print '[INFO] deleting source objects from bucket ' + args.s3_reporter_bucket

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -29,12 +29,7 @@ def convert(keys_array):
     file_list = ' '.join(id_array)
 
     # TODO: error handling?
-    #cmd = 'datastore-histogram-tile-writer --time-bucket' + ' ' + str(args.time_bucket) + ' ' + '--tile ' + str(args.tile_id) + ' ' + '-f flatbuffer_file -o orc_file' + ' ' + file_list
-    #print('[INFO] Running the following conversion cmd: ' + cmd)
-    #cmd = 'echo WHAT_IS_GOING_ON'
-
     sys.stdout.flush()
-    #process = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, timeout=300, universal_newlines=True)
     process = subprocess.check_output(['datastore-histogram-tile-writer', '--time-bucket', str(args.time_bucket), '--tile', str(args.tile_id), '-f', 'flatbuffer_file', '-o', 'orc_file', file_list], stderr=subprocess.STDOUT, timeout=300, universal_newlines=True)
     print('[INFO] Finished running conversion')
 

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -29,8 +29,8 @@ def convert():
     cmd = 'datastore-histogram-tile-writer -v -b ' + str(args.time_bucket) + '-t ' + str(args.tile_id) + ' -f /work/flatbuffer_file ' + '-o /work/orc_file /work/*'
     proc = subprocess.run(cmd, timeout=300, universal_newlines=True, stderr=subprocess.STDOUT, shell=True)
     out,err = proc.communicate()
-    print out
-    print err
+    print(out)
+    print(err)
 
     print('[INFO] Finished running conversion')
 

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,25 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=WARN, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+log4j.logger.io.opentraffic.datastore=DEBUG

--- a/tests/circle.sh
+++ b/tests/circle.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-output_file=/output/output.fb
-
 mkdir output
 
 echo "Starting the datastore container..."
@@ -11,11 +9,11 @@ docker run \
   -v ${PWD}/tests/work-data:/work \
   -v ${PWD}/output:/output \
   datastore:latest \
-  sh -c 'datastore-histogram-tile-writer -b $((1478023200/3600)) -t $(((2140 << 3) | 0)) -v -f ${output_file} /work/1478023200_1478026799/0/2140/*'
+  sh -c 'datastore-histogram-tile-writer -b $((1478023200/3600)) -t $(((2140 << 3) | 0)) -v -f /output/flatbuffer.fb /work/1478023200_1478026799/0/2140/*'
 
-if [ -f ${output_file} ]; then
+if [ -f /output/flatbuffer.fb ]; then
   echo "Success!"
-  ls -l ${output_file}
+  ls -l /output/flatbuffer.fb
   exit 0
 else
   echo "Failed: output file doesn't exist or is zero length!"

--- a/tests/circle.sh
+++ b/tests/circle.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-mkdir output
+mkdir /output
 
 echo "Starting the datastore container..."
 docker run \

--- a/tests/circle.sh
+++ b/tests/circle.sh
@@ -1,19 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
-mkdir output
-
 echo "Starting the datastore container..."
 docker run \
   --name datastore \
   -v ${PWD}/tests/work-data:/work \
-  -v ${PWD}/output:${PWD}/output \
   datastore:latest \
-  sh -c 'datastore-histogram-tile-writer -b $((1478023200/3600)) -t $(((2140 << 3) | 0)) -v -f output/flatbuffer.fb /work/1478023200_1478026799/0/2140/*'
+  sh -c 'datastore-histogram-tile-writer -b $((1478023200/3600)) -t $(((2140 << 3) | 0)) -v -f flatbuffer.fb /work/1478023200_1478026799/0/2140/*'
 
-if [ -f output/flatbuffer.fb ]; then
+if [ -f ${PWD}/tests/work-data/flatbuffer.fb ]; then
   echo "Success!"
-  ls -l output/flatbuffer.fb
+  ls -l ${PWD}/tests/work-data/flatbuffer.fb
   exit 0
 else
   echo "Failed: output file doesn't exist or is zero length!"

--- a/tests/circle.sh
+++ b/tests/circle.sh
@@ -11,7 +11,7 @@ docker run \
   -v ${PWD}/tests/work-data:/work \
   -v ${PWD}/output:/output \
   datastore:latest \
-  datastore-histogram-tile-writer -b $((1478023200/3600)) -t $(((2140 << 3) | 0)) -v -f ${output_file} /work/1478023200_1478026799/0/2140/*
+  sh -c 'datastore-histogram-tile-writer -b $((1478023200/3600)) -t $(((2140 << 3) | 0)) -v -f ${output_file} /work/1478023200_1478026799/0/2140/*'
 
 if [ -f ${output_file} ]; then
   echo "Success!"

--- a/tests/circle.sh
+++ b/tests/circle.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 set -e
 
-mkdir /output
+mkdir output
 
 echo "Starting the datastore container..."
 docker run \
   --name datastore \
   -v ${PWD}/tests/work-data:/work \
-  -v ${PWD}/output:/output \
+  -v ${PWD}/output:${PWD}/output \
   datastore:latest \
-  sh -c 'datastore-histogram-tile-writer -b $((1478023200/3600)) -t $(((2140 << 3) | 0)) -v -f /output/flatbuffer.fb /work/1478023200_1478026799/0/2140/*'
+  sh -c 'datastore-histogram-tile-writer -b $((1478023200/3600)) -t $(((2140 << 3) | 0)) -v -f output/flatbuffer.fb /work/1478023200_1478026799/0/2140/*'
 
-if [ -f /output/flatbuffer.fb ]; then
+if [ -f output/flatbuffer.fb ]; then
   echo "Success!"
-  ls -l /output/flatbuffer.fb
+  ls -l output/flatbuffer.fb
   exit 0
 else
   echo "Failed: output file doesn't exist or is zero length!"


### PR DESCRIPTION
- various docker and circle test updates
- addition of `scripts/work.py` which is executed by AWS Batch, having received units of work from Lambda (https://github.com/opentraffic/datastore-lambda/blob/master/batch.py). It will download files from S3, transform them using the java proc to flatbuffer/orc, and upload the results to S3.