### PR TITLE
add random speed tile generation in pbf flavor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ target
 .project
 .settings
 .classpath
+scripts/io
+scripts/*.pyc
+scripts/segment_pb2.py
+scripts/speedtile_pb2.py
+scripts/tile_pb2.py

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,12 @@ target
 .project
 .settings
 .classpath
-scripts/io
 scripts/*.pyc
+srcipts/*.fbs
 scripts/segment_pb2.py
 scripts/speedtile_pb2.py
 scripts/tile_pb2.py
+scripts/Entry.py
+scripts/Histogram.py
+scripts/Segment.py
+scripts/VehicleType.py

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "osmlr-tile-spec"]
+	path = osmlr-tile-spec
+	url = https://github.com/opentraffic/osmlr-tile-spec.git

--- a/proto/segment.proto
+++ b/proto/segment.proto
@@ -1,0 +1,1 @@
+../osmlr-tile-spec/segment.proto

--- a/proto/speedtile.proto
+++ b/proto/speedtile.proto
@@ -1,0 +1,54 @@
+syntax = "proto2";
+package SizeTest;
+
+message SpeedTile {
+  
+  //this allows us to chunk up large tiles into smaller pieces
+  repeated SubTile subtiles = 1;
+  message SubTile {
+    //tile information, where this is
+    optional uint32 level = 1;  //the tile level
+    optional uint32 index = 2;  //the tile index
+
+    //what segments will be found in this tile
+    optional uint32 startSegmentIndex = 3; //the first segment index in the subtile
+                                           //makes up the highest 21 bits of of the segment id
+    optional uint32 totalSegments = 11;    //how many segments there are across all subtiles in this tile
+                                           //these may be in this message or in another proto message
+
+    //time information, when this is
+    //Note: that it represent both a single ordinal unit in time (if rangeEnd - rangeStart == unitSize)
+    //but also be an average unit over a longer period of time (if rangeEnd - rangeStart > unitSize)
+    optional uint32 rangeStart = 4; //epoch start time (inclusive) seconds
+    optional uint32 rangeEnd = 5;   //epoch end time (exclusive) seconds
+    optional uint32 unitSize = 6;   //target time range seconds, a week would be 604800
+    optional uint32 entrySize = 7;  //target time range granularity seconds, an hour would be 3600
+
+    optional string description = 8; //text describing the time period this covers
+
+    repeated Segment segments = 9;          //the segments in order
+    repeated NextSegment nextSegments = 10; //all next segments in blocks referenced by above segments
+
+    message Segment {
+      optional uint32 referenceSpeed = 1;  //the default speed of the segment
+      repeated Entry entries = 2;          //all the entries for the given unit of time
+                                           //should be a total of unitSize/entrySize entries
+      message Entry {
+        optional uint32 speed = 1;            //the average speed
+        optional float speedVariance = 2;     //the variance between samples
+        optional uint32 prevalence = 3;       //a rough indication of how many samples
+        optional uint32 nextSegmentIndex = 4; //an index into the next segment array
+        optional uint32 nextSegmentCount = 5; //total next segments for this segment
+      }
+    }
+
+    message NextSegment {
+      optional uint64 id = 1;                 //full mask of tile and level and id
+      optional uint32 delay = 2;              //delay in seconds from average speed
+      optional float delayVariance = 3;       //variance of delay samples
+      optional uint32 queueLength = 4;        //length of any queue on segment
+      optional float queueLengthVariance = 5; //variance of queue length samples
+    }
+  }
+
+}

--- a/proto/tile.proto
+++ b/proto/tile.proto
@@ -1,0 +1,1 @@
+../osmlr-tile-spec/tile.proto

--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+import argparse
+import random
+import os
+import errno
+import sys
+
+try:
+  import segment_pb2
+  import tile_pb2
+  import speedtile_pb2
+except ImportError:
+  print 'You need to generate protobuffer source via: protoc --python_out . --proto_path ../proto ../proto/*.proto'
+  sys.exit(1)
+
+try:
+  import io.opentraffic.datastore.flatbuffer.Entry
+  import io.opentraffic.datastore.flatbuffer.Histogram
+  import io.opentraffic.datastore.flatbuffer.Segment
+  import io.opentraffic.datastore.flatbuffer.VehicleType
+except ImportError:
+  print 'You need to generate the flatbuffer soruce via: flatc --python ../src/main/fbs/histogram-tile.fbs'
+  sys.exit(1)
+
+#try this fat tile: wget https://s3.amazonaws.com/osmlr-tiles/v0.1/pbf/2/000/724/159.osmlr
+
+def getIds(fileName):
+  osmlr = tile_pb2.Tile()
+  with open(fileName, 'rb') as f:
+    osmlr.ParseFromString(f.read())
+
+  #get out the segment ids
+  segId = 0
+  segmentIds = []
+  for entry in osmlr.entries:
+    if entry.segment:
+      segmentIds.append(segId)
+    else:
+      segmentIds.append(-1)
+    segId += 1
+
+  del osmlr
+  return segmentIds
+
+def write(name, count, tile):
+  name += '.' + str(count)
+  print 'writing subtile to ' + name
+  with open(name, 'ab') as f:
+    f.write(tile.SerializeToString())
+  print 'wrote subtile to ' + name
+
+def next(startIndex, total, nextName):
+  print 'creating new subtile starting at ' + str(startIndex)
+  tile = speedtile_pb2.SpeedTile()
+  subtile = tile.subtiles.add()
+  if nextName:
+    nextTile = speedtile_pb2.SpeedTile()
+    nextSubtile = nextTile.subtiles.add()
+  else:
+    nextTile = tile
+    nextSubtile = subtile
+  for st in [subtile, nextSubtile]:
+    #geo stuff
+    st.level = 0      #TODO: get from osmlr
+    st.index = 2415   #TODO: get from osmlr
+    st.startSegmentIndex = startIndex
+    st.totalSegments = total
+    #time stuff
+    st.rangeStart = 1483228800 #TODO: get from input
+    st.rangeEnd = 1483833600   #TODO: get from input
+    st.unitSize = 604800       #TODO: get from input
+    st.entrySize = 3600        #TODO: get from input
+    st.description = '168 ordinal hours of week 0 of year 2017' #TODO: get from input
+  return tile, subtile, nextTile, nextSubtile
+
+def remove(path):
+  try:
+    print 'Removing ' + path
+    os.remove(path)
+  except OSError as e:
+    if e.errno != errno.ENOENT:
+      raise
+
+def simulate(segmentIds, fileName, subTileSize, nextName, separate):
+  random.seed(0)
+
+  #fake a segment for each entry in the osmlr
+  tile = None
+  nextTile = None
+  subTileCount = 0
+  first = True
+  for i, sid in enumerate(segmentIds):
+    #its time to write a subtile
+    if i % subTileSize == 0:
+      #writing tile
+      if tile is not None:
+        remove(fileName) if first else None
+        write(fileName, subTileCount, tile)
+        #writing next data if its separated
+        if nextTile is not tile:
+          remove(nextName) if first else None
+          write(nextName, subTileCount, nextTile)
+        #dont delete the files from this point on
+        first = False
+        #if the subtiles are to be separate increment
+        if separate:
+          subTileCount += 1
+        #release all memory
+        del subtile
+        del tile
+        del nextSubtile
+        del nextTile
+      #set up new pbf messages to write into
+      tile, subtile, nextTile, nextSubtile = next(i, len(segmentIds), nextName)
+
+    #continue making fake data
+    segment = subtile.segments.add()
+    if sid == -1: #need blank one to keep the indices correct
+      continue
+    segment.referenceSpeed = random.randint(20, 100)
+    nextIds = [ (random.randint(0,2**21)<<25)|(subtile.index<<3)|subtile.level for i in range(0, random.randint(0,3)) ]
+    for i in range(0, subtile.unitSize/subtile.entrySize):
+      entry = segment.entries.add()
+      entry.speed = random.randint(20, 100)
+      entry.speedVariance = random.uniform(0,1)
+      entry.prevalence = random.randint(1, 100)
+      entry.nextSegmentIndex = len(subtile.nextSegments)
+      entry.nextSegmentCount = len(nextIds)
+      for nid in nextIds:
+        nextSegment = nextSubtile.nextSegments.add();
+        nextSegment.id = nid
+        nextSegment.delay = random.randint(0,30)
+        nextSegment.delayVariance = random.uniform(0,1)
+        nextSegment.queueLength = random.randint(0,200)
+        nextSegment.queueLengthVariance = random.uniform(0,1)
+
+  #get the last one written
+  if tile is not None:
+    remove(fileName) if first else None
+    write(fileName, subTileCount, tile)
+    if nextTile is not tile:
+      remove(nextName) if first else None
+      write(nextName, subTileCount, nextTile)
+    del subtile
+    del tile
+    del nextSubtile
+    del nextTile
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description='Generate fake speed tiles', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+  parser.add_argument('--output-prefix', type=str, help='The file name prefix to give to output tiles. The first tile will have no suffix, after that they will be numbered starting at 1. e.g. tile.spd, tile.spd.1, tile.spd.2', default='tile.spd')
+  parser.add_argument('--max-segments', type=int, help='The maximum number of segments to have in a single subtile message', default=10000)
+  parser.add_argument('--no-separate-subtiles', help='If present all subtiles will be in the same tile', action='store_true')
+  parser.add_argument('--separate-next-segments-prefix', type=str, help='The prefix for the next segments output tiles if they should be separated from the primary speed entries. If omitted they will not be separate')
+  parser.add_argument('--osmlr', type=str, help='The osmlr tile containing the relevant segments definitions')
+  parser.add_argument('flatbuffers', metavar='N', type=str, nargs='+', help='The flatbuffer tiles for the time period in question')
+  #TODO: add the time period argument
+  #TODO: add the tile id argument until we can get it from osmlr
+  args = parser.parse_args()
+
+  print 'getting osmlr segments'
+  ids = getIds(args.osmlr)
+  
+  print 'simulating 1 week of speeds at hourly intervals for ' + str(len(ids)) + ' segments'
+  simulate(ids, args.output_prefix, args.max_segments, args.separate_next_segments_prefix, not args.no_separate_subtiles)
+
+  print 'done'

--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -42,8 +42,18 @@ def getIds(fileName):
   del osmlr
   return segmentIds
 
-def write(name, count, tile):
+def remove(path):
+  try:
+    print 'Removing ' + path
+    os.remove(path)
+  except OSError as e:
+    if e.errno != errno.ENOENT:
+      raise
+
+def write(name, count, tile, should_remove):
   name += '.' + str(count)
+  if should_remove:
+    remove(name)
   print 'writing subtile to ' + name
   with open(name, 'ab') as f:
     f.write(tile.SerializeToString())
@@ -73,14 +83,6 @@ def next(startIndex, total, nextName):
     st.description = '168 ordinal hours of week 0 of year 2017' #TODO: get from input
   return tile, subtile, nextTile, nextSubtile
 
-def remove(path):
-  try:
-    print 'Removing ' + path
-    os.remove(path)
-  except OSError as e:
-    if e.errno != errno.ENOENT:
-      raise
-
 def simulate(segmentIds, fileName, subTileSize, nextName, separate):
   random.seed(0)
 
@@ -94,12 +96,10 @@ def simulate(segmentIds, fileName, subTileSize, nextName, separate):
     if i % subTileSize == 0:
       #writing tile
       if tile is not None:
-        remove(fileName) if first else None
-        write(fileName, subTileCount, tile)
+        write(fileName, subTileCount, tile, first or separate)
         #writing next data if its separated
         if nextTile is not tile:
-          remove(nextName) if first else None
-          write(nextName, subTileCount, nextTile)
+          write(nextName, subTileCount, nextTile, first or separate)
         #dont delete the files from this point on
         first = False
         #if the subtiles are to be separate increment
@@ -136,11 +136,9 @@ def simulate(segmentIds, fileName, subTileSize, nextName, separate):
 
   #get the last one written
   if tile is not None:
-    remove(fileName) if first else None
-    write(fileName, subTileCount, tile)
+    write(fileName, subTileCount, tile, first or separate)
     if nextTile is not tile:
-      remove(nextName) if first else None
-      write(nextName, subTileCount, nextTile)
+      write(nextName, subTileCount, nextTile, first or separate)
     del subtile
     del tile
     del nextSubtile

--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -19,7 +19,7 @@ try:
   import Segment
   import VehicleType
 except ImportError:
-  print 'You need to generate the flatbuffer soruce via: sed -e "/namespace.*/d" ../src/main/fbs/histogram-tile.fbs > schema.fbs && flatc --python schema.fbs'
+  print 'You need to generate the flatbuffer source via: sed -e "/namespace.*/d" ../src/main/fbs/histogram-tile.fbs > schema.fbs && flatc --python schema.fbs'
   sys.exit(1)
 
 #try this fat tile: wget https://s3.amazonaws.com/osmlr-tiles/v0.1/pbf/2/000/724/159.osmlr

--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -14,12 +14,12 @@ except ImportError:
   sys.exit(1)
 
 try:
-  import io.opentraffic.datastore.flatbuffer.Entry
-  import io.opentraffic.datastore.flatbuffer.Histogram
-  import io.opentraffic.datastore.flatbuffer.Segment
-  import io.opentraffic.datastore.flatbuffer.VehicleType
+  import Entry
+  import Histogram
+  import Segment
+  import VehicleType
 except ImportError:
-  print 'You need to generate the flatbuffer soruce via: flatc --python ../src/main/fbs/histogram-tile.fbs'
+  print 'You need to generate the flatbuffer soruce via: sed -e "/namespace.*/d" ../src/main/fbs/histogram-tile.fbs > schema.fbs && flatc --python schema.fbs'
   sys.exit(1)
 
 #try this fat tile: wget https://s3.amazonaws.com/osmlr-tiles/v0.1/pbf/2/000/724/159.osmlr


### PR DESCRIPTION
related to #48 

---

note: this program imports the flatbuffer modules but it doesnt actually do anything with flatbuffers that is a `todo` for @kdiluca and @dgearhart

anyway this makes pbf files witih speed information similar to the original json we were working towards. i reworked the notion of the time period covered by the tile to make more since (imho). ive also remove the ids themselves from the tile and just put in the tile level and index and then made the segments sequential (which is good because they are sorted this way in osmlr and in flatbuffers). it also reduces the size of the files. 

there are a couple of things we may be able to do to make the file size smaller. since protobuf uses varint we could possible switch the variances to use this so long as we keep the absolute value of them small, this would require math when using the value client side but could make the files smaller. we could also measure average speed as the difference from reference speed also we'd have the problem of negative numbers so maybe we couldnt make that work...

take a look at the speedtile proto definition and see if it meets our needs. its split up in 2 ways to make it so we can store just the right amount of data without getting fancy with geographic partitioning. the first way its split up is by a top level object called `Tile` which only holds an array of `SubTile`s. in this way any number of `Tile`s in different files can just be concatenated to get all the data in one place if desired. what this allows (as described in #48) is splitting up the segment index space (defaults to 10k per subtile) so that a client only has a portion of all ids at any one time but with some simple math can know what subtile will hold a given segment index should they need it. 

the second way the tiles are broken up is at the `SubTile` level where its basically again two arrays, one of `Entry`s and another of `NextSegment`s where we can store one or the other or both or none in a given `SubTile`. This lets us easily separate the `NextSegment` entries from the regular speed entries if we want to so that client applications can treat that info as optional.

The program in this pr lets you configure all of the above via arguments.

When all is said and done the largest tile, which is the level 2 tokyo tile (so large it cant be created using the json methodology as its well over a gig of json) comes down to the following:

```console
./make_speeds.py --output-prefix 415.spd --separate-next-segments-prefix 415.nex --osmlr ../../size_test/159.osmlr blah
getting osmlr segments
simulating 1 week of speeds at hourly intervals for 107973 segments
creating new subtile starting at 0
Removing 415.spd.0
writing subtile to 415.spd.0
wrote subtile to 415.spd.0
Removing 415.nex.0
writing subtile to 415.nex.0
wrote subtile to 415.nex.0
creating new subtile starting at 10000
Removing 415.spd.1
writing subtile to 415.spd.1
wrote subtile to 415.spd.1
Removing 415.nex.1
writing subtile to 415.nex.1
wrote subtile to 415.nex.1
creating new subtile starting at 20000
Removing 415.spd.2
writing subtile to 415.spd.2
wrote subtile to 415.spd.2
Removing 415.nex.2
writing subtile to 415.nex.2
wrote subtile to 415.nex.2
creating new subtile starting at 30000
Removing 415.spd.3
writing subtile to 415.spd.3
wrote subtile to 415.spd.3
Removing 415.nex.3
writing subtile to 415.nex.3
wrote subtile to 415.nex.3
creating new subtile starting at 40000
Removing 415.spd.4
writing subtile to 415.spd.4
wrote subtile to 415.spd.4
Removing 415.nex.4
writing subtile to 415.nex.4
wrote subtile to 415.nex.4
creating new subtile starting at 50000
Removing 415.spd.5
writing subtile to 415.spd.5
wrote subtile to 415.spd.5
Removing 415.nex.5
writing subtile to 415.nex.5
wrote subtile to 415.nex.5
creating new subtile starting at 60000
Removing 415.spd.6
writing subtile to 415.spd.6
wrote subtile to 415.spd.6
Removing 415.nex.6
writing subtile to 415.nex.6
wrote subtile to 415.nex.6
creating new subtile starting at 70000
Removing 415.spd.7
writing subtile to 415.spd.7
wrote subtile to 415.spd.7
Removing 415.nex.7
writing subtile to 415.nex.7
wrote subtile to 415.nex.7
creating new subtile starting at 80000
Removing 415.spd.8
writing subtile to 415.spd.8
wrote subtile to 415.spd.8
Removing 415.nex.8
writing subtile to 415.nex.8
wrote subtile to 415.nex.8
creating new subtile starting at 90000
Removing 415.spd.9
writing subtile to 415.spd.9
wrote subtile to 415.spd.9
Removing 415.nex.9
writing subtile to 415.nex.9
wrote subtile to 415.nex.9
creating new subtile starting at 100000
Removing 415.spd.10
writing subtile to 415.spd.10
wrote subtile to 415.spd.10
Removing 415.nex.10
writing subtile to 415.nex.10
wrote subtile to 415.nex.10
done
```
some uncompressed sizes:
```console
foo:bar$ ls -hal --sort time *nex* *spd*
-rw-r--r-- 1 kkreiser kkreiser 47M Aug  8 09:52 415.nex.10
-rw-r--r-- 1 kkreiser kkreiser 20M Aug  8 09:52 415.spd.10
-rw-r--r-- 1 kkreiser kkreiser 59M Aug  8 09:51 415.nex.9
-rw-r--r-- 1 kkreiser kkreiser 25M Aug  8 09:50 415.spd.9
-rw-r--r-- 1 kkreiser kkreiser 59M Aug  8 09:49 415.nex.8
-rw-r--r-- 1 kkreiser kkreiser 25M Aug  8 09:48 415.spd.8
-rw-r--r-- 1 kkreiser kkreiser 59M Aug  8 09:47 415.nex.7
-rw-r--r-- 1 kkreiser kkreiser 25M Aug  8 09:46 415.spd.7
-rw-r--r-- 1 kkreiser kkreiser 59M Aug  8 09:45 415.nex.6
-rw-r--r-- 1 kkreiser kkreiser 25M Aug  8 09:44 415.spd.6
-rw-r--r-- 1 kkreiser kkreiser 59M Aug  8 09:43 415.nex.5
-rw-r--r-- 1 kkreiser kkreiser 25M Aug  8 09:42 415.spd.5
-rw-r--r-- 1 kkreiser kkreiser 59M Aug  8 09:41 415.nex.4
-rw-r--r-- 1 kkreiser kkreiser 25M Aug  8 09:40 415.spd.4
-rw-r--r-- 1 kkreiser kkreiser 59M Aug  8 09:39 415.nex.3
-rw-r--r-- 1 kkreiser kkreiser 25M Aug  8 09:38 415.spd.3
-rw-r--r-- 1 kkreiser kkreiser 59M Aug  8 09:37 415.nex.2
-rw-r--r-- 1 kkreiser kkreiser 25M Aug  8 09:36 415.spd.2
-rw-r--r-- 1 kkreiser kkreiser 60M Aug  8 09:35 415.nex.1
-rw-r--r-- 1 kkreiser kkreiser 25M Aug  8 09:34 415.spd.1
-rw-r--r-- 1 kkreiser kkreiser 59M Aug  8 09:33 415.nex.0
-rw-r--r-- 1 kkreiser kkreiser 25M Aug  8 09:33 415.spd.0
```

some compressed sizes:

```console
foo:bar$ ls -hal --sort time *nex* *spd*
-rw-r--r-- 1 kkreiser kkreiser  23M Aug  8 09:52 415.nex.10.gz
-rw-r--r-- 1 kkreiser kkreiser 9.0M Aug  8 09:52 415.spd.10.gz
-rw-r--r-- 1 kkreiser kkreiser  29M Aug  8 09:51 415.nex.9.gz
-rw-r--r-- 1 kkreiser kkreiser  12M Aug  8 09:50 415.spd.9.gz
-rw-r--r-- 1 kkreiser kkreiser  29M Aug  8 09:49 415.nex.8.gz
-rw-r--r-- 1 kkreiser kkreiser  12M Aug  8 09:48 415.spd.8.gz
-rw-r--r-- 1 kkreiser kkreiser  29M Aug  8 09:47 415.nex.7.gz
-rw-r--r-- 1 kkreiser kkreiser  12M Aug  8 09:46 415.spd.7.gz
-rw-r--r-- 1 kkreiser kkreiser  29M Aug  8 09:45 415.nex.6.gz
-rw-r--r-- 1 kkreiser kkreiser  12M Aug  8 09:44 415.spd.6.gz
-rw-r--r-- 1 kkreiser kkreiser  29M Aug  8 09:43 415.nex.5.gz
-rw-r--r-- 1 kkreiser kkreiser  12M Aug  8 09:42 415.spd.5.gz
-rw-r--r-- 1 kkreiser kkreiser  29M Aug  8 09:41 415.nex.4.gz
-rw-r--r-- 1 kkreiser kkreiser  12M Aug  8 09:40 415.spd.4.gz
-rw-r--r-- 1 kkreiser kkreiser  29M Aug  8 09:39 415.nex.3.gz
-rw-r--r-- 1 kkreiser kkreiser  12M Aug  8 09:38 415.spd.3.gz
-rw-r--r-- 1 kkreiser kkreiser  29M Aug  8 09:37 415.nex.2.gz
-rw-r--r-- 1 kkreiser kkreiser  12M Aug  8 09:36 415.spd.2.gz
-rw-r--r-- 1 kkreiser kkreiser  30M Aug  8 09:35 415.nex.1.gz
-rw-r--r-- 1 kkreiser kkreiser  12M Aug  8 09:34 415.spd.1.gz
-rw-r--r-- 1 kkreiser kkreiser  29M Aug  8 09:33 415.nex.0.gz
-rw-r--r-- 1 kkreiser kkreiser  12M Aug  8 09:33 415.spd.0.gz
```

above you'll see `spd` files and `nex` files as well as numerical suffixes. this is because i've chosen for this run to split the tiles in both ways mentioned above, where subtiles are different files (numerical suffixes) and where speed data is separated from next segment data (spd vs nex file names).