### PR TITLE
make everything be repeated, the client will have a rough time but th…

### DIFF
--- a/proto/speedtile.proto
+++ b/proto/speedtile.proto
@@ -13,42 +13,33 @@ message SpeedTile {
     //what segments will be found in this tile
     optional uint32 startSegmentIndex = 3; //the first segment index in the subtile
                                            //makes up the highest 21 bits of of the segment id
-    optional uint32 totalSegments = 11;    //how many segments there are across all subtiles in this tile
+    optional uint32 totalSegments = 4;     //how many segments there are across all subtiles in this tile
                                            //these may be in this message or in another proto message
+    optional uint32 subtileSegments = 5;   //the total number of segments in this subtile should be the same
+                                           //for all subtiles except the last one might have less
 
     //time information, when this is
     //Note: that it represent both a single ordinal unit in time (if rangeEnd - rangeStart == unitSize)
     //but also be an average unit over a longer period of time (if rangeEnd - rangeStart > unitSize)
-    optional uint32 rangeStart = 4; //epoch start time (inclusive) seconds
-    optional uint32 rangeEnd = 5;   //epoch end time (exclusive) seconds
-    optional uint32 unitSize = 6;   //target time range seconds, a week would be 604800
-    optional uint32 entrySize = 7;  //target time range granularity seconds, an hour would be 3600
+    optional uint32 rangeStart = 6; //epoch start time (inclusive) seconds
+    optional uint32 rangeEnd = 7;   //epoch end time (exclusive) seconds
+    optional uint32 unitSize = 8;   //target time range seconds, a week would be 604800
+    optional uint32 entrySize = 9;  //target time range granularity seconds, an hour would be 3600
 
-    optional string description = 8; //text describing the time period this covers
+    optional string description = 10; //text describing the time period this covers
 
-    repeated Segment segments = 9;          //the segments in order
-    repeated NextSegment nextSegments = 10; //all next segments in blocks referenced by above segments
+    repeated uint32 referenceSpeeds = 11 [packed=true];   //the default speed of the each segment
+    repeated uint32 speeds = 12 [packed=true];            //the average speed of each segment of each entry
+    repeated uint32 speedVariances = 13 [packed=true];    //the variance between samples of each segment of each entry, also fixed precision
+    repeated uint32 prevalences = 14 [packed=true];       //a rough indication of how many samples of ecah segment of each entry
+    repeated uint32 nextSegmentIndices = 15 [packed=true];//an index into the next segment array of a given entry of a given segment
+    repeated uint32 nextSegmentCounts = 16 [packed=true]; //total next segments for this segment of a given entry of a given segment
 
-    message Segment {
-      optional uint32 referenceSpeed = 1;  //the default speed of the segment
-      repeated Entry entries = 2;          //all the entries for the given unit of time
-                                           //should be a total of unitSize/entrySize entries
-      message Entry {
-        optional uint32 speed = 1;            //the average speed
-        optional float speedVariance = 2;     //the variance between samples
-        optional uint32 prevalence = 3;       //a rough indication of how many samples
-        optional uint32 nextSegmentIndex = 4; //an index into the next segment array
-        optional uint32 nextSegmentCount = 5; //total next segments for this segment
-      }
-    }
-
-    message NextSegment {
-      optional uint64 id = 1;                 //full mask of tile and level and id
-      optional uint32 delay = 2;              //delay in seconds from average speed
-      optional float delayVariance = 3;       //variance of delay samples
-      optional uint32 queueLength = 4;        //length of any queue on segment
-      optional float queueLengthVariance = 5; //variance of queue length samples
-    }
+    repeated uint64 nextSegmentIds = 17;                  //full mask of tile and level and id from corresponding  entry
+    repeated uint32 nextSegmentDelays = 18;               //delay in seconds from average speed from corresponding entry
+    repeated uint32 nextSegmentDelayVariances = 19;       //variance of delay samples from corresponding entry
+    repeated uint32 nextSegmentQueueLengths = 20;         //length of any queue on segment from corresponding entry
+    repeated uint32 nextSegmentQueueLengthVariances = 21; //variance of queue length samples from corresponding entry
   }
 
 }

--- a/proto/speedtile.proto
+++ b/proto/speedtile.proto
@@ -35,11 +35,11 @@ message SpeedTile {
     repeated uint32 nextSegmentIndices = 15 [packed=true];//an index into the next segment array of a given entry of a given segment
     repeated uint32 nextSegmentCounts = 16 [packed=true]; //total next segments for this segment of a given entry of a given segment
 
-    repeated uint64 nextSegmentIds = 17;                  //full mask of tile and level and id from corresponding  entry
-    repeated uint32 nextSegmentDelays = 18;               //delay in seconds from average speed from corresponding entry
-    repeated uint32 nextSegmentDelayVariances = 19;       //variance of delay samples from corresponding entry
-    repeated uint32 nextSegmentQueueLengths = 20;         //length of any queue on segment from corresponding entry
-    repeated uint32 nextSegmentQueueLengthVariances = 21; //variance of queue length samples from corresponding entry
+    repeated uint64 nextSegmentIds = 17 [packed=true];                  //full mask of tile and level and id from corresponding  entry
+    repeated uint32 nextSegmentDelays = 18 [packed=true];               //delay in seconds from average speed from corresponding entry
+    repeated uint32 nextSegmentDelayVariances = 19 [packed=true];       //variance of delay samples from corresponding entry
+    repeated uint32 nextSegmentQueueLengths = 20 [packed=true];         //length of any queue on segment from corresponding entry
+    repeated uint32 nextSegmentQueueLengthVariances = 21 [packed=true]; //variance of queue length samples from corresponding entry
   }
 
 }


### PR DESCRIPTION
…e files are smaller

this cuts the size quite substantially. if you remember from #49 you can see that the worst case tile had lots of large parts. with this change we could probably up the total number of segments per subtile. note that this will not decrease memory demands client side, it really only impacts the serialized pbf (it compresses better this way) once you deserialize it client side it will still be just as fat as before.

@drewda @dnesbitt61 @louh 

here's the new sizes:

```console
foo:bar$ ls -hal *.gz
-rw-r--r-- 1 kkreiser kkreiser 9.2M Aug  8 13:54 415.nex.0.gz
-rw-r--r-- 1 kkreiser kkreiser 7.3M Aug  8 14:04 415.nex.10.gz
-rw-r--r-- 1 kkreiser kkreiser 9.3M Aug  8 13:55 415.nex.1.gz
-rw-r--r-- 1 kkreiser kkreiser 9.2M Aug  8 13:56 415.nex.2.gz
-rw-r--r-- 1 kkreiser kkreiser 9.2M Aug  8 13:57 415.nex.3.gz
-rw-r--r-- 1 kkreiser kkreiser 9.2M Aug  8 13:58 415.nex.4.gz
-rw-r--r-- 1 kkreiser kkreiser 9.1M Aug  8 13:59 415.nex.5.gz
-rw-r--r-- 1 kkreiser kkreiser 9.2M Aug  8 14:00 415.nex.6.gz
-rw-r--r-- 1 kkreiser kkreiser 9.1M Aug  8 14:01 415.nex.7.gz
-rw-r--r-- 1 kkreiser kkreiser 9.1M Aug  8 14:03 415.nex.8.gz
-rw-r--r-- 1 kkreiser kkreiser 9.2M Aug  8 14:04 415.nex.9.gz
-rw-r--r-- 1 kkreiser kkreiser 4.7M Aug  8 13:54 415.spd.0.gz
-rw-r--r-- 1 kkreiser kkreiser 3.7M Aug  8 14:04 415.spd.10.gz
-rw-r--r-- 1 kkreiser kkreiser 4.7M Aug  8 13:55 415.spd.1.gz
-rw-r--r-- 1 kkreiser kkreiser 4.7M Aug  8 13:56 415.spd.2.gz
-rw-r--r-- 1 kkreiser kkreiser 4.7M Aug  8 13:57 415.spd.3.gz
-rw-r--r-- 1 kkreiser kkreiser 4.7M Aug  8 13:58 415.spd.4.gz
-rw-r--r-- 1 kkreiser kkreiser 4.7M Aug  8 13:59 415.spd.5.gz
-rw-r--r-- 1 kkreiser kkreiser 4.7M Aug  8 14:00 415.spd.6.gz
-rw-r--r-- 1 kkreiser kkreiser 4.7M Aug  8 14:01 415.spd.7.gz
-rw-r--r-- 1 kkreiser kkreiser 4.7M Aug  8 14:02 415.spd.8.gz
-rw-r--r-- 1 kkreiser kkreiser 4.7M Aug  8 14:03 415.spd.9.gz
```