### PR TITLE
Added speed, delay, and queue length variances

### DIFF
--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -291,16 +291,26 @@ def createSpeedTiles(lengths, fileName, subTileSize, nextName, separate, segment
       if nextSegments:
         for nid, n in nextSegments.iteritems():
           n['duration'] /= float(n['count'])
-          n['queue'] /= float(n['count'])          
-      
+          n['queue'] /= float(n['count'])
+
+      # Compute the speed and speed variance
+      if nextSegments:
+        # create speed list in kph instead of meters per second
+        speeds = [int(round(length / n['duration'] * 3.6)) for nid, n in nextSegments.iteritems()]
+        # calculate mean speed
+        meanSpeed = sum(speeds) / float(len(speeds))
+        # calculate speed variance
+        varSpeed = int(round(sum([(xi - meanSpeed)**2 for xi in speeds]) / len(speeds)))
+    
       #any time its a dead one we put in 0's for the data
       minDuration = min([n['duration'] for nid, n in nextSegments.iteritems()]) if nextSegments else 0
-      # assign speed as kph instead of meters per sec
-      subtile.speeds.append(int(round(length / minDuration * 3.6 if nextSegments else 0)))
+      # assign speed in kph
+      subtile.speeds.append(max(speeds) if nextSegments else 0)
+
       #DEBUG
       if nextSegments:
-        print 'segmentId=' + str((k<<25)|(args.tile_id<<3)|args.level) + ' | nextSegments=' + str(nextSegments) + ' | length=' + str(length) + ' | minDuration=' + str(minDuration) + ' | speed=' + str((int(round(length / minDuration * 3.6 if nextSegments else 0))))
-      #subtile.speedVariances.append(TODO if nextSegments else 0)
+        print 'segmentId=' + str((k<<25)|(args.tile_id<<3)|args.level) + ' | nextSegments=' + str(nextSegments) + ' | length=' + str(length) + ' | minDuration=' + str(minDuration) + ' | speed=' + str(max(speeds)) + ' | varSpeed=' + str(varSpeed)
+      subtile.speedVariances.append(varSpeed if nextSegments else 0)
       subtile.prevalences.append(prevalance(sum([n['count'] for nid, n in nextSegments.iteritems()]) if nextSegments else 0))
       subtile.nextSegmentIndices.append(len(subtile.nextSegmentIds) if 1 else 0)
       subtile.nextSegmentCounts.append(len(nextSegments) if nextSegments else 0)

--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -321,13 +321,15 @@ def createSpeedTiles(lengths, fileName, subTileSize, nextName, separate, segment
       if nextSegments:
         # create delay list
         delays = [int(round(n['duration'] - minDuration)) for nid, n in nextSegments.iteritems()]
+        # create queue length list
+        queueLengths = [float(n['queue']) for nid, n in nextSegments.iteritems()]
         # assign next segment attributes
         for nid, n in nextSegments.iteritems():
           nextSubtile.nextSegmentIds.append(nid)
           nextSubtile.nextSegmentDelays.append(int(round(n['duration'] - minDuration)))
           nextSubtile.nextSegmentDelayVariances.append(variance(delays))
           nextSubtile.nextSegmentQueueLengths.append(int(round(n['queue'])))
-          #nextSubtile.nextSegmentQueueLengthVariances.append(TODO)
+          nextSubtile.nextSegmentQueueLengthVariances.append(variance(queueLengths))
 
   #get the last one written
   if tile is not None:

--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -91,7 +91,6 @@ def getSegments(path, target_level, target_tile_id, lengths):
 ###############################################################################
 def processSegment(segments, segment, length):
   for i in range(0, segment.EntriesLength()):
-    #TODO: measure variance
     e = segment.Entries(i)
     #get the right segment
     if segment.SegmentId() not in segments:
@@ -241,6 +240,14 @@ def prevalance(val):
   return int(round(val / 10.0) * 10)
 
 ###############################################################################
+# calculate and return the variance of the specified list
+def variance(items):
+  # calculate mean
+  mean = sum(items) / float(len(items))
+  # calculate and return the variance
+  return int(round(sum([(xi - mean)**2 for xi in items]) / len(items)))
+
+###############################################################################
 #method simulates generation of speed data by populating with real data from osmlr
 #and reporter results converted to fb output
 def createSpeedTiles(lengths, fileName, subTileSize, nextName, separate, segments):
@@ -293,15 +300,10 @@ def createSpeedTiles(lengths, fileName, subTileSize, nextName, separate, segment
           n['duration'] /= float(n['count'])
           n['queue'] /= float(n['count'])
 
-      # Compute the speed and speed variance
+      # create speed list in kph instead of meters per second
       if nextSegments:
-        # create speed list in kph instead of meters per second
         speeds = [int(round(length / n['duration'] * 3.6)) for nid, n in nextSegments.iteritems()]
-        # calculate mean speed
-        meanSpeed = sum(speeds) / float(len(speeds))
-        # calculate speed variance
-        varSpeed = int(round(sum([(xi - meanSpeed)**2 for xi in speeds]) / len(speeds)))
-    
+
       #any time its a dead one we put in 0's for the data
       minDuration = min([n['duration'] for nid, n in nextSegments.iteritems()]) if nextSegments else 0
       # assign speed in kph
@@ -309,17 +311,21 @@ def createSpeedTiles(lengths, fileName, subTileSize, nextName, separate, segment
 
       #DEBUG
       if nextSegments:
-        print 'segmentId=' + str((k<<25)|(args.tile_id<<3)|args.level) + ' | nextSegments=' + str(nextSegments) + ' | length=' + str(length) + ' | minDuration=' + str(minDuration) + ' | speed=' + str(max(speeds)) + ' | varSpeed=' + str(varSpeed)
-      subtile.speedVariances.append(varSpeed if nextSegments else 0)
+        print 'segmentId=' + str((k<<25)|(args.tile_id<<3)|args.level) + ' | nextSegments=' + str(nextSegments) + ' | length=' + str(length) + ' | minDuration=' + str(minDuration) + ' | speed=' + str(max(speeds)) + ' | varSpeed=' + str(variance(speeds))
+
+      subtile.speedVariances.append(variance(speeds) if nextSegments else 0)
       subtile.prevalences.append(prevalance(sum([n['count'] for nid, n in nextSegments.iteritems()]) if nextSegments else 0))
       subtile.nextSegmentIndices.append(len(subtile.nextSegmentIds) if 1 else 0)
       subtile.nextSegmentCounts.append(len(nextSegments) if nextSegments else 0)
 
       if nextSegments:
+        # create delay list
+        delays = [int(round(n['duration'] - minDuration)) for nid, n in nextSegments.iteritems()]
+        # assign next segment attributes
         for nid, n in nextSegments.iteritems():
           nextSubtile.nextSegmentIds.append(nid)
           nextSubtile.nextSegmentDelays.append(int(round(n['duration'] - minDuration)))
-          #nextSubtile.nextSegmentDelayVariances.append(TODO)
+          nextSubtile.nextSegmentDelayVariances.append(variance(delays))
           nextSubtile.nextSegmentQueueLengths.append(int(round(n['queue'])))
           #nextSubtile.nextSegmentQueueLengthVariances.append(TODO)
 

--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -280,7 +280,7 @@ def createSpeedTiles(lengths, fileName, subTileSize, nextName, separate, segment
       tile, subtile, nextTile, nextSubtile = next(k, len(lengths), nextName, subTileSize)
 
 
-    #continue making fake data
+    #TODO
     #subtile.referenceSpeeds.append(random.randint(20, 100) if length > 0 else 0)
 
     #do all the entries


### PR DESCRIPTION
paired with @gknisely to add the variances

verified in the speed tile output and UI

segmentId=845336824696 | nextSegments={190085876600: {'count': 133, 'duration': 19.57894736842105, 'queue': 4.235588972431078}, 854698511224: {'count': 3, 'duration': 33.333333333333336, 'queue': 54.56601307189542}} | length=169 | minDuration=19.5789473684 | speed=31 | varSpeed=42

![screenshot from 2017-08-25 14-33-37](https://user-images.githubusercontent.com/7515853/29727597-9f7b34e6-89a2-11e7-9988-2a0127972b0b.png)
