### PR TITLE
Make Reference Speed Tiles

### DIFF
--- a/proto/speedtile.proto
+++ b/proto/speedtile.proto
@@ -40,10 +40,10 @@ message SpeedTile {
     repeated uint32 nextSegmentQueueLengths = 20 [packed=true];         //length of any queue on segment from corresponding entry
     repeated uint32 nextSegmentQueueLengthVariances = 21 [packed=true]; //variance of queue length samples from corresponding entry
 
-    repeated uint32 referenceSpeed20 = 22 [packed=true]; //20% are this or slower than this specific ref speed for each segment
-    repeated uint32 referenceSpeed40 = 23 [packed=true]; //40% are this or slower than this specific ref speed for each segment
-    repeated uint32 referenceSpeed60 = 24 [packed=true]; //60% are this or slower than this specific ref speed for each segment
-    repeated uint32 referenceSpeed80 = 25 [packed=true]; //80% are this or slower than this specific ref speed for each segment
+    repeated uint32 referenceSpeeds20 = 22 [packed=true]; //20% are this speed or slower than this specific ref speed for each segment
+    repeated uint32 referenceSpeeds40 = 23 [packed=true]; //40% are this speed or slower than this specific ref speed for each segment
+    repeated uint32 referenceSpeeds60 = 24 [packed=true]; //60% are this speed or slower than this specific ref speed for each segment
+    repeated uint32 referenceSpeeds80 = 25 [packed=true]; //80% are this speed or slower than this specific ref speed for each segment
 
   }
 

--- a/proto/speedtile.proto
+++ b/proto/speedtile.proto
@@ -25,10 +25,9 @@ message SpeedTile {
     optional uint32 rangeEnd = 7;   //epoch end time (exclusive) seconds
     optional uint32 unitSize = 8;   //target time range seconds, a week would be 604800
     optional uint32 entrySize = 9;  //target time range granularity seconds, an hour would be 3600
-
     optional string description = 10; //text describing the time period this covers
+    optional uint32 deprecated=11;
 
-    repeated uint32 referenceSpeeds = 11 [packed=true];   //the default speed of the each segment
     repeated uint32 speeds = 12 [packed=true];            //the average speed of each segment of each entry
     repeated uint32 speedVariances = 13 [packed=true];    //the variance between samples of each segment of each entry, also fixed precision
     repeated uint32 prevalences = 14 [packed=true];       //a rough indication of how many samples of ecah segment of each entry
@@ -40,6 +39,12 @@ message SpeedTile {
     repeated uint32 nextSegmentDelayVariances = 19 [packed=true];       //variance of delay samples from corresponding entry
     repeated uint32 nextSegmentQueueLengths = 20 [packed=true];         //length of any queue on segment from corresponding entry
     repeated uint32 nextSegmentQueueLengthVariances = 21 [packed=true]; //variance of queue length samples from corresponding entry
+
+    repeated uint32 referenceSpeed20 = 22 [packed=true]; //20% are this or slower than this specific ref speed for each segment
+    repeated uint32 referenceSpeed40 = 23 [packed=true]; //40% are this or slower than this specific ref speed for each segment
+    repeated uint32 referenceSpeed60 = 24 [packed=true]; //60% are this or slower than this specific ref speed for each segment
+    repeated uint32 referenceSpeed80 = 25 [packed=true]; //80% are this or slower than this specific ref speed for each segment
+
   }
 
 }

--- a/scripts/convert_to_fb.py
+++ b/scripts/convert_to_fb.py
@@ -21,7 +21,7 @@ def convert(dictionary):
     level = str(key[1])
     tile_index = str(key[2])
     tile_id = str((int(tile_index) << 3) | int(level))
-    date = "/2017/1/2/"
+    date = "/2017/1/1/"
     file_path = args.datastore_bucket + date + hour + "/" + level + '/' 
     out_dir = os.path.dirname(file_path)
     if not os.path.exists(out_dir):
@@ -37,7 +37,6 @@ def convert(dictionary):
     except subprocess.CalledProcessError as tilewriter:
       print('[ERROR] Failed running datastore-histogram-tile-writer:', tilewriter.returncode, tilewriter.output)
       sys.exit([tilewriter.returncode])
-
     print('[INFO] Finished running conversion')
 
 

--- a/scripts/make_fbs_batch.sh
+++ b/scripts/make_fbs_batch.sh
@@ -2,7 +2,7 @@
 
 # Call python script to convert all reporter results to flatbuffer files
 
-reporter_results="/data/reporter/results"
-flatbuffer_output="/data/datastore/flatbuffer_output"
+reporter_results="/data/opentraffic/reporter/results"
+flatbuffer_output="/data/opentraffic/datastore_output_local"
 
-./convert_to_fb.py --reporter-path  ${reporter_results} --datastore-bucket ${flatbuffer_output}
+./scripts/convert_to_fb.py --reporter-path  ${reporter_results} --datastore-bucket ${flatbuffer_output}

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -71,9 +71,9 @@ def createAvgSpeedList(fileNames):
       for i, speed in enumerate(subtile.speeds):
         segmentIndex = subtile.startSegmentIndex + int(math.floor(i/entries))
         log.debug('SPEED: i=' + str(i) + ' | segmentIndex=' + str(segmentIndex) + ' | segmentId=' + str((segmentIndex<<25)|(subtile.index<<3)|subtile.level) + ' | speed=' + str(speed))
-        if speed > 0:
+        if speed > 0 and speed <= 160:
           segments[segmentIndex].append(speed)
-        if speed > 200:
+        elif speed > 160:
           log.error('INVALID SPEED: i=' + str(i) + ' | segmentIndex=' + str(segmentIndex) + ' | segmentId=' + str((segmentIndex<<25)|(subtile.index<<3)|subtile.level) + ' | speed=' + str(speed))
 
   #sort each list of speeds per segment

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -21,12 +21,12 @@ except ImportError:
 ### segment1{refspdlist[hour0:avgspd, hour1:avgspd, hour2:avgspd, etc]}
 # get the avg speeds for a given segment for each hour (168 hr/day) over 52 weeks
 
-def createAvgSpeedList(fileNameList):
+def createAvgSpeedList(fileNames):
   #each segment has its own list of speeds, we dont know how many segments for the avg speed list to start with
   segments = []
 
   #need to loop thru all of the speed tiles for a given tile id
-  for fileName in fileNameList:
+  for fileName in fileNames:
     #lets load the protobuf speed tile
     spdtile = speedtile_pb2.SpeedTile()
     with open(fileName, 'rb') as f:
@@ -42,9 +42,10 @@ def createAvgSpeedList(fileNameList):
       
       print 'total # created in segments ' + str(subtile.totalSegments)
       entries = subtile.unitSize / subtile.entrySize
+      print '# of entries per segment : ' + str(entries)
       for i, speed in enumerate(subtile.speeds):
         if speed > 0:
-          segments[subtile.startSegmentIndex + (i%entries)].append(speed)
+          segments[subtile.startSegmentIndex + int(math.floor(i/entries))].append(speed)
           #print 'index=' + str(i) + ' | speeds=' + str(speed) + '| startSegmentIndex+i= ' + str(subtile.startSegmentIndex + (i%entries))
 
   #sort each list of speeds per segment
@@ -78,19 +79,87 @@ def createRefSpeedTile(path, fileName, speedListPerSegment):
   #for each segment
   for segment in speedListPerSegment:
     size = len(segment)
-    st.referenceSpeed20.append(segment[int(size * .2)] if size > 0 else 0) #0 here represents no data
-    st.referenceSpeed40.append(segment[int(size * .4)] if size > 0 else 0) #0 here represents no data
-    st.referenceSpeed60.append(segment[int(size * .6)] if size > 0 else 0) #0 here represents no data
-    st.referenceSpeed80.append(segment[int(size * .8)] if size > 0 else 0) #0 here represents no data
+    st.referenceSpeeds20.append(segment[int(size * .2)] if size > 0 else 0) #0 here represents no data
+    st.referenceSpeeds40.append(segment[int(size * .4)] if size > 0 else 0) #0 here represents no data
+    st.referenceSpeeds60.append(segment[int(size * .6)] if size > 0 else 0) #0 here represents no data
+    st.referenceSpeeds80.append(segment[int(size * .8)] if size > 0 else 0) #0 here represents no data
 
-  print str(st.referenceSpeed20)
-  print str(st.referenceSpeed40)
-  print str(st.referenceSpeed60)
-  print str(st.referenceSpeed80)
+  #print str(st.referenceSpeeds20)
+  #print str(st.referenceSpeeds40)
+  #print str(st.referenceSpeeds60)
+  #print str(st.referenceSpeeds80)
 
   #write it out
   with open(path + fileName, 'ab') as f:
     f.write(tile.SerializeToString())
+
+###############################################################################
+    #world bb
+minx_ = -180
+miny_ = -90
+maxx_ = 180
+maxy_ = 90
+
+class BoundingBox(object):
+
+  def __init__(self, min_x, min_y, max_x, max_y):
+     self.minx = min_x
+     self.miny = min_y
+     self.maxx = max_x
+     self.maxy = max_y
+
+class TileHierarchy(object):
+
+  def __init__(self):
+    self.levels = {}
+    # local
+    self.levels[2] = Tiles(BoundingBox(minx_,miny_,maxx_,maxy_),.25)
+    # arterial
+    self.levels[1] = Tiles(BoundingBox(minx_,miny_,maxx_,maxy_),1)
+    # highway
+    self.levels[0] = Tiles(BoundingBox(minx_,miny_,maxx_,maxy_),4)
+
+class Tiles(object):
+
+  def __init__(self, bbox, size):
+     self.bbox = bbox
+     self.tilesize = size
+
+     self.ncolumns = int(math.ceil((self.bbox.maxx - self.bbox.minx) / self.tilesize))
+     self.nrows = int(math.ceil((self.bbox.maxy - self.bbox.miny) / self.tilesize))
+     self.max_tile_id = ((self.ncolumns * self.nrows) - 1)
+
+  def Digits(self, number):
+    digits = 1 if (number < 0) else 0
+    while long(number):
+       number /= 10
+       digits += 1
+    return long(digits)
+
+  # get the File based on tile_id and level
+  def GetFile(self, tile_id, level):
+    max_length = self.Digits(self.max_tile_id)
+
+    remainder = max_length % 3
+    if remainder:
+       max_length += 3 - remainder
+
+    #if it starts with a zero the pow trick doesn't work
+    if level == 0:
+      file_suffix = '{:,}'.format(int(pow(10, max_length)) + tile_id).replace(',', '/')
+      file_suffix += "."
+      file_suffix += "spd.*.gz"
+      file_suffix = "0" + file_suffix[1:]
+      return file_suffix
+
+    #it was something else
+    file_suffix = '{:,}'.format(level * int(pow(10, max_length)) + tile_id).replace(',', '/')
+    file_suffix += "."
+    file_suffix += "spd.*.gz"
+
+    return file_suffix
+
+###############################################################################
 
 #Read in protobuf files from the datastore output in AWS to read in the lengths, speeds & next segment ids and generate the segment speed files in proto output format
 if __name__ == "__main__":
@@ -99,11 +168,34 @@ if __name__ == "__main__":
   parser.add_argument('--ref-tile-path', type=str, help='The public data extract speed tile containing the average speeds per segment per hour of day for one week', required=True)
   parser.add_argument('--output-prefix', type=str, help='The file name prefix to give to output tile.')
   parser.add_argument('--verbose', '-v', help='Turn on verbose output i.e. DEBUG level logging', action='store_true')
+  parser.add_argument('--bucket', type=str, help='AWS bucket location', required=True)
+  parser.add_argument('--year', type=str, help='The year you wish to get', required=True)
+  parser.add_argument('--level', type=int, help='The level to target', required=True)
+  parser.add_argument('--tile-id', type=int, help='The tile id to target', required=True)
+  parser.add_argument('--no-separate-subtiles', help='If present all subtiles will be in the same tile', action='store_true')
 
   # parse the arguments
   args = parser.parse_args()
 
+  tile_hierarchy = TileHierarchy()
+
+  url_prefix = "https://s3.amazonaws.com/" + args.bucket + "/" + args.year + "/"
+
+  weeks_per_year = 52
+  week = 0
+  #urls = []
+  while ( week < weeks_per_year):
+    url = url_prefix + str(week) + "/"
+    file_name = tile_hierarchy.levels[args.level].GetFile(args.tile_id, args.level)
+    url += file_name
+    week += 1
+    #urls.append(url)
+    print url
+
+################################################################################
+
   print 'getting avg speeds from list of protobuf speed tile extracts'
+  #speedListPerSegment = createAvgSpeedList(fileNames)
   speedListPerSegment = createAvgSpeedList(args.speedtile_list)
   
   #print 'create reference speed tiles for each segment'

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -35,17 +35,16 @@ def createAvgSpeedList(fileNameList):
     for subtile in spdtile.subtiles:
 
       #make sure that there are enough lists in the list for all segments
-      print 'total # of segments in subtile ' + str(subtile.totalSegments)
       print 'length of avg speed list per segment ' + str(len(speedListPerSegment))
       missing = len(speedListPerSegment) - subtile.totalSegments
       if missing > 0:
         speedListPerSegment.extend([ [] for i in range(0, missing) ])
  
-      print '# of speeds for a subtile ' + str(len(subtile.speeds))
+      print 'total # of segments ' + str(subtile.totalSegments) 
       for i, speed in enumerate(subtile.speeds):
-        if speed > 0:
-          print str(subtile.startSegmentIndex + i) + ',' +str(speed)
-          speedListPerSegment[subtile.startSegmentIndex + i].append(speed)
+        if speedListPerSegment[subtile.startSegmentIndex + i]:
+          if speed is not 0:
+            speedListPerSegment[subtile.startSegmentIndex + i].append(speed)
 
 
     #sort each list of speeds per segment

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -23,7 +23,7 @@ except ImportError:
 
 def createAvgSpeedList(fileNameList):
   #each segment has its own list of speeds, we dont know how many segments for the avg speed list to start with
-  speedListPerSegment = []
+  segments = []
 
   #need to loop thru all of the speed tiles for a given tile id
   for fileName in fileNameList:
@@ -36,23 +36,24 @@ def createAvgSpeedList(fileNameList):
     for subtile in spdtile.subtiles:
 
       #make sure that there are enough lists in the list for all segments
-      missing = subtile.totalSegments - len(speedListPerSegment)
+      missing = spdtile.subtiles[0].totalSegments - len(segments)
       if missing > 0:
-        speedListPerSegment.extend([ [] for i in range(0, missing) ])
-      #print 'total # created in speedListPerSegment ' + str(len(speedListPerSegment))
-
+        segments.extend([ [] for i in range(0, missing) ])
+      
+      print 'total # created in segments ' + str(subtile.totalSegments)
       entries = subtile.unitSize / subtile.entrySize
-
       for i, speed in enumerate(subtile.speeds):
-        if speed and speed > 0:
-          speedListPerSegment[subtile.startSegmentIndex + (i%entries)].append(speed)
-          print 'index=' + str(i) + ' | speeds=' + str(speed) + '| startSegmentIndex+i= ' + str(subtile.startSegmentIndex + (i%entries))
+        if speed > 0:
+          segments[subtile.startSegmentIndex + (i%entries)].append(speed)
+          #print 'index=' + str(i) + ' | speeds=' + str(speed) + '| startSegmentIndex+i= ' + str(subtile.startSegmentIndex + (i%entries))
 
-      speedListPerSegment = filter(None, speedListPerSegment)
-      #sort hi to lo
-      speedListPerSegment.sort()
+  #sort each list of speeds per segment
+  for i, segment in enumerate(segments):
+    if len(segment) > 0:
+      print '# of valid average speeds in segment ' + str(i) + ' is ' + str(len(segment))
+    segment.sort()
 
-  return speedListPerSegment
+  return segments
 
 ###############################################################################
 def createRefSpeedTile(path, fileName, speedListPerSegment):
@@ -77,10 +78,10 @@ def createRefSpeedTile(path, fileName, speedListPerSegment):
   #for each segment
   for segment in speedListPerSegment:
     size = len(segment)
-    st.referenceSpeed20.append(segment[int(size * .2)])
-    st.referenceSpeed40.append(segment[int(size * .4)])
-    st.referenceSpeed60.append(segment[int(size * .6)])
-    st.referenceSpeed80.append(segment[int(size * .8)])
+    st.referenceSpeed20.append(segment[int(size * .2)] if size > 0 else 0) #0 here represents no data
+    st.referenceSpeed40.append(segment[int(size * .4)] if size > 0 else 0) #0 here represents no data
+    st.referenceSpeed60.append(segment[int(size * .6)] if size > 0 else 0) #0 here represents no data
+    st.referenceSpeed80.append(segment[int(size * .8)] if size > 0 else 0) #0 here represents no data
 
   print str(st.referenceSpeed20)
   print str(st.referenceSpeed40)

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -166,16 +166,27 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser(description='Generate speed tiles', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
   parser.add_argument('--speedtile-list', type=str, nargs='+', help='A list of the PDE speed tiles containing the average speeds per segment per hour of day for one week')
   parser.add_argument('--ref-tile-path', type=str, help='The public data extract speed tile containing the average speeds per segment per hour of day for one week', required=True)
-  parser.add_argument('--output-prefix', type=str, help='The file name prefix to give to output tile.')
-  parser.add_argument('--verbose', '-v', help='Turn on verbose output i.e. DEBUG level logging', action='store_true')
+  parser.add_argument('--ref-tile-file', type=str, help='The ref tile file name.')
   parser.add_argument('--bucket', type=str, help='AWS bucket location', required=True)
   parser.add_argument('--year', type=str, help='The year you wish to get', required=True)
   parser.add_argument('--level', type=int, help='The level to target', required=True)
   parser.add_argument('--tile-id', type=int, help='The tile id to target', required=True)
   parser.add_argument('--no-separate-subtiles', help='If present all subtiles will be in the same tile', action='store_true')
+  parser.add_argument('--verbose', '-v', help='Turn on verbose output i.e. DEBUG level logging', action='store_true')
 
   # parse the arguments
   args = parser.parse_args()
+
+  # setup log
+  if args.verbose:
+    log.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s', stream=sys.stdout, level=log.DEBUG)
+    log.debug('ref-tile-path=' + args.ref_tile_path)
+    log.debug('bucket=' + args.bucket)
+    log.debug('year=' + args.year)
+    log.debug('level=' + str(args.level))
+    log.debug('tile-id=' + str(args.tile_id))
+  else:
+    log.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s', stream=sys.stdout)
 
   tile_hierarchy = TileHierarchy()
 
@@ -199,7 +210,7 @@ if __name__ == "__main__":
   speedListPerSegment = createAvgSpeedList(args.speedtile_list)
   
   #print 'create reference speed tiles for each segment'
-  createRefSpeedTile(args.ref_tile_path, args.output_prefix, speedListPerSegment)
+  createRefSpeedTile(args.ref_tile_path, args.ref_tile_file, speedListPerSegment)
 
   if args.verbose:
     log.debug('loop over segments ###############################################################################')

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -17,6 +17,13 @@ except ImportError:
   print 'You need to generate protobuffer source via: protoc --python_out . --proto_path ../proto ../proto/*.proto'
   sys.exit(1)
 
+###############################################################################
+#world bb
+minx_ = -180
+miny_ = -90
+maxx_ = 180
+maxy_ = 90
+
 def get_tile_count(filename):
   #lets load the protobuf speed tile
   spdtile = speedtile_pb2.SpeedTile()
@@ -102,13 +109,6 @@ def createRefSpeedTile(path, fileName, speedListPerSegment):
   #write it out
   with open(path + fileName, 'ab') as f:
     f.write(tile.SerializeToString())
-
-###############################################################################
-#world bb
-minx_ = -180
-miny_ = -90
-maxx_ = 180
-maxy_ = 90
 
 class BoundingBox(object):
 

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -41,10 +41,12 @@ def createAvgSpeedList(fileNameList):
         speedListPerSegment.extend([ [] for i in range(0, missing) ])
       #print 'total # created in speedListPerSegment ' + str(len(speedListPerSegment))
 
+      entries = subtile.unitSize / subtile.entrySize
+
       for i, speed in enumerate(subtile.speeds):
         if speed and speed > 0:
-          speedListPerSegment.insert(subtile.startSegmentIndex + i, speed)
-          #print 'index=' + str(i) + ' | speeds=' + str(speed) + '| startSegmentIndex+1= ' + str(subtile.startSegmentIndex + i)
+          speedListPerSegment[subtile.startSegmentIndex + (i%entries)].append(speed)
+          print 'index=' + str(i) + ' | speeds=' + str(speed) + '| startSegmentIndex+i= ' + str(subtile.startSegmentIndex + (i%entries))
 
       speedListPerSegment = filter(None, speedListPerSegment)
       #sort hi to lo
@@ -70,19 +72,20 @@ def createRefSpeedTile(path, fileName, speedListPerSegment):
   st.entrySize = st.unitSize
   st.description = 'Reference speeds over 1 year from 08.2016 through 07.2017' #TODO: get this from range start and end
 
-
-  #for each segment
   print 'speedListPerSegment length: ' + str(len(speedListPerSegment))
   #bucketize avg speeds into 20%, 40%, 60% and 80% reference speed buckets
-  size = len(speedListPerSegment)
-  print speedListPerSegment[int(size * .2)]
-  print speedListPerSegment[int(size * .4)]
-  print speedListPerSegment[int(size * .6)]
-  print speedListPerSegment[int(size * .8)]
-  st.referenceSpeed20.append(speedListPerSegment[int(size * .2)])
-  st.referenceSpeed40.append(speedListPerSegment[int(size * .4)])
-  st.referenceSpeed60.append(speedListPerSegment[int(size * .6)])
-  st.referenceSpeed80.append(speedListPerSegment[int(size * .8)])
+  #for each segment
+  for segment in speedListPerSegment:
+    size = len(segment)
+    st.referenceSpeed20.append(segment[int(size * .2)])
+    st.referenceSpeed40.append(segment[int(size * .4)])
+    st.referenceSpeed60.append(segment[int(size * .6)])
+    st.referenceSpeed80.append(segment[int(size * .8)])
+
+  print str(st.referenceSpeed20)
+  print str(st.referenceSpeed40)
+  print str(st.referenceSpeed60)
+  print str(st.referenceSpeed80)
 
   #write it out
   with open(path + fileName, 'ab') as f:

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -50,7 +50,8 @@ def createAvgSpeedList(fileNames):
       for i, speed in enumerate(subtile.speeds):
         if speed > 0:
           segments[subtile.startSegmentIndex + int(math.floor(i/entries))].append(speed)
-          #print 'index=' + str(i) + ' | speeds=' + str(speed) + '| startSegmentIndex+i= ' + str(subtile.startSegmentIndex + (i%entries))
+        if speed > 200:
+          log.debug('INVALID SPEED:: index=' + str(i) + ' | speeds=' + str(speed) + '| startSegmentIndex= ' + str(subtile.startSegmentIndex + int(math.floor(i/entries))))
 
   #sort each list of speeds per segment
   for i, segment in enumerate(segments):

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -152,20 +152,20 @@ class Tiles(object):
     if level == 0:
       file_suffix = '{:,}'.format(int(pow(10, max_length)) + tile_id).replace(',', '/')
       file_suffix += "."
-      file_suffix += "spd.0.gz"
+      file_suffix += "spd.0"
       file_suffix = "0" + file_suffix[1:]
       return file_suffix
 
     #it was something else
     file_suffix = '{:,}'.format(level * int(pow(10, max_length)) + tile_id).replace(',', '/')
     file_suffix += "."
-    file_suffix += "spd.0.gz"
+    file_suffix += "spd.0"
 
     return file_suffix
 
 ###############################################################################
 
-#Read in protobuf files from the datastore output in AWS to read in the lengths, speeds & next segment ids and generate the segment speed files in proto output format
+# Read in protobuf files from the datastore output in AWS to read in the lengths, speeds & next segment ids and generate the segment speed files in proto output format
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(description='Generate speed tiles', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
   parser.add_argument('--speedtile-list', type=str, nargs='+', help='A list of the PDE speed tiles containing the average speeds per segment per hour of day for one week')
@@ -192,7 +192,10 @@ if __name__ == "__main__":
   else:
     log.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s', stream=sys.stdout)
 
+################################################################################
 
+  # download the speed tiles from aws and decompress
+  spdFileNames = []
   directory = "ref_working_dir/"
   shutil.rmtree(directory, ignore_errors=True)
   tile_hierarchy = TileHierarchy()
@@ -206,7 +209,6 @@ if __name__ == "__main__":
     key = key_prefix + str(week) + "/"
     file_name = tile_hierarchy.levels[args.level].GetFile(args.tile_id, args.level)
     key += file_name
-    #print key
     try:
       file_path = os.path.dirname(key + ".gz" )
       if not os.path.exists(directory + file_path):
@@ -224,13 +226,14 @@ if __name__ == "__main__":
     with open(directory + key , 'w') as outfile:
       outfile.write(decompressedFile.read())
 
+    spdFileNames.append(outfile.name)
     week += 1
 
 ################################################################################
 
   print 'getting avg speeds from list of protobuf speed tile extracts'
-  #speedListPerSegment = createAvgSpeedList(fileNames)
-  speedListPerSegment = createAvgSpeedList(args.speedtile_list)
+  speedListPerSegment = createAvgSpeedList(spdFileNames)
+  #speedListPerSegment = createAvgSpeedList(args.speedtile_list)
   
   #print 'create reference speed tiles for each segment'
   createRefSpeedTile(args.ref_tile_path, args.ref_tile_file, speedListPerSegment)

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -20,7 +20,7 @@ except ImportError:
 ### segment0{refspdlist[hour0:avgspd, hour1:avgspd, hour2:avgspd, etc]} -> sort lo to hi, index in to get refspd20:int, refspd40:int, refspd60:int, refspd80:int
 ### segment1{refspdlist[hour0:avgspd, hour1:avgspd, hour2:avgspd, etc]}
 # get the avg speeds for a given segment for each hour (168 hr/day) over 52 weeks
-<<<<<<< HEAD
+
 def createAvgSpeedList(fileNameList):
   #each segment has its own list of speeds, we dont know how many segments for the avg speed list to start with
   speedListPerSegment = []
@@ -36,52 +36,53 @@ def createAvgSpeedList(fileNameList):
     for subtile in spdtile.subtiles:
 
       #make sure that there are enough lists in the list for all segments
-      print 'length of avg speed list per segment ' + str(len(speedListPerSegment))
-      missing = len(speedListPerSegment) - subtile.totalSegments
+      missing = subtile.totalSegments - len(speedListPerSegment)
       if missing > 0:
         speedListPerSegment.extend([ [] for i in range(0, missing) ])
- 
-      print 'total # of segments ' + str(subtile.totalSegments) 
+      #print 'total # created in speedListPerSegment ' + str(len(speedListPerSegment))
+
       for i, speed in enumerate(subtile.speeds):
-        if speedListPerSegment[subtile.startSegmentIndex + i]:
-          if speed is not 0:
-            speedListPerSegment[subtile.startSegmentIndex + i].append(speed)
+        if speed and speed > 0:
+          speedListPerSegment.insert(subtile.startSegmentIndex + i, speed)
+          #print 'index=' + str(i) + ' | speeds=' + str(speed) + '| startSegmentIndex+1= ' + str(subtile.startSegmentIndex + i)
 
-
-    #sort each list of speeds per segment
-    for i, segment in enumerate(speedListPerSegment):
-      print '# of valid average speeds in segment ' + str(i) + ' is ' + str(len(speedListPerSegment))
-      #sort lo to hi
+      speedListPerSegment = filter(None, speedListPerSegment)
+      #sort hi to lo
       speedListPerSegment.sort()
 
   return speedListPerSegment
-  
+
 ###############################################################################
-def createRefSpeedTile(path, fileName, avgspdlist):
+def createRefSpeedTile(path, fileName, speedListPerSegment):
   log.debug('createRefSpeedTiles ###############################################################################')
 
   tile = speedtile_pb2.SpeedTile()
   st = tile.subtiles.add()
-  st.level = #TODO: get from osmlr
-  st.index = #TODO: get from osmlr
+  #st.level = 0 #TODO: get from osmlr
+  #st.index = 415 #TODO: get from osmlr
   st.startSegmentIndex = 0
-  st.totalSegments = len(avgspdlist)
-  st.subtileSegments = len(avgspdlist)
+  st.totalSegments = len(speedListPerSegment)
+  st.subtileSegments = len(speedListPerSegment)
   #time stuff
-  st.rangeStart = #TODO: first second since epoch of first week you have data for
-  st.rangeEnd = #TODO: last second since epoch of last week you have data for
+  #st.rangeStart = #TODO: first second since epoch of first week you have data for
+  #st.rangeEnd = #TODO: last second since epoch of last week you have data for
   st.unitSize = st.rangeEnd - st.rangeStart
   st.entrySize = st.unitSize
   st.description = 'Reference speeds over 1 year from 08.2016 through 07.2017' #TODO: get this from range start and end
 
 
   #for each segment
-  for segment in avgspdlist:
-    size = len(segment)
-    st.referenceSpeed20(segment[round(size * .2)])
-    st.referenceSpeed40(segment[round(size * .2)])
-    st.referenceSpeed60(segment[round(size * .2)])
-    st.referenceSpeed80(segment[round(size * .2)])
+  print 'speedListPerSegment length: ' + str(len(speedListPerSegment))
+  #bucketize avg speeds into 20%, 40%, 60% and 80% reference speed buckets
+  size = len(speedListPerSegment)
+  print speedListPerSegment[int(size * .2)]
+  print speedListPerSegment[int(size * .4)]
+  print speedListPerSegment[int(size * .6)]
+  print speedListPerSegment[int(size * .8)]
+  st.referenceSpeed20.append(speedListPerSegment[int(size * .2)])
+  st.referenceSpeed40.append(speedListPerSegment[int(size * .4)])
+  st.referenceSpeed60.append(speedListPerSegment[int(size * .6)])
+  st.referenceSpeed80.append(speedListPerSegment[int(size * .8)])
 
   #write it out
   with open(path + fileName, 'ab') as f:
@@ -90,24 +91,25 @@ def createRefSpeedTile(path, fileName, avgspdlist):
 #Read in protobuf files from the datastore output in AWS to read in the lengths, speeds & next segment ids and generate the segment speed files in proto output format
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(description='Generate speed tiles', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-  parser.add_argument('--speedtile-list', type=str, nargs='+', help='A list of the public data extract speed tiles containing the average speeds per segment per hour of day for one week')
+  parser.add_argument('--speedtile-list', type=str, nargs='+', help='A list of the PDE speed tiles containing the average speeds per segment per hour of day for one week')
   parser.add_argument('--ref-tile-path', type=str, help='The public data extract speed tile containing the average speeds per segment per hour of day for one week', required=True)
-  parser.add_argument('--output-prefix', type=str, help='The file name prefix to give to output tiles. The first tile will have no suffix, after that they will be numbered starting at 1. e.g. tile.ref, tile.ref.1, tile.ref.2', default='tile.ref')
+  parser.add_argument('--output-prefix', type=str, help='The file name prefix to give to output tile.')
   parser.add_argument('--verbose', '-v', help='Turn on verbose output i.e. DEBUG level logging', action='store_true')
 
   # parse the arguments
   args = parser.parse_args()
 
   print 'getting avg speeds from list of protobuf speed tile extracts'
-  avgspdlist = createAvgSpeedList(args.speedtile_list)
+  speedListPerSegment = createAvgSpeedList(args.speedtile_list)
   
   #print 'create reference speed tiles for each segment'
-  createRefSpeedTile(args.ref_tile_path, args.output_prefix, avgspdlist)
+  createRefSpeedTile(args.ref_tile_path, args.output_prefix, speedListPerSegment)
 
   if args.verbose:
     log.debug('loop over segments ###############################################################################')
-    for i,speeds in enumerate(segments):
-      log.debug('index=' + str(i) + ' | speeds=' + str(speeds))
+    for i, speed in enumerate(speedListPerSegment):
+      log.debug('index=' + str(i) + ' | speeds=' + str(speed))
+
     log.debug('DONE loop over segments ###############################################################################')
 
   print 'done'

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+import argparse
+import random
+import math
+import os
+import errno
+import sys
+import logging as log
+
+try:
+  import speedtile_pb2
+except ImportError:
+  print 'You need to generate protobuffer source via: protoc --python_out . --proto_path ../proto ../proto/*.proto'
+  sys.exit(1)
+
+#wget https://s3.amazonaws.com/speed-extracts/2017/0/0/002/415.spd.*.gz
+
+###############################################################################
+### tile 2415
+### segment0{refspdlist[hour0:avgspd, hour1:avgspd, hour2:avgspd, etc]} -> sort lo to hi, index in to get refspd20:int, refspd40:int, refspd60:int, refspd80:int
+### segment1{refspdlist[hour0:avgspd, hour1:avgspd, hour2:avgspd, etc]}
+# get the avg speeds for a given segment for each hour (168 hr/day) over 52 weeks
+def createAvgSpeedList(fileName):
+  spdtile = speedtile_pb2.SpeedTile()
+  with open(fileName, 'rb') as f:
+    spdtile.ParseFromString(f.read())
+    
+  #get out the average speed
+  avgspdlist = []
+  for subtile in spdtile.subtiles:
+    print 'total # of segments ' + str(subtile.totalSegments) 
+    print '# of speeds for a subtile ' + str(len(subtile.speeds))
+    for speed in subtile.speeds:
+      if speed > 0:
+        avgspdlist.append(speed)
+  del spdtile
+    
+  print '# of valid average speeds in list ' + str(len(avgspdlist))
+  #sort lo to hi
+  avgspdlist.sort()  
+  return avgspdlist
+  
+###############################################################################
+  
+def remove(path):
+  try:
+    os.remove(path)
+  except OSError as e:
+    if e.errno != errno.ENOENT:
+      raise
+
+###############################################################################
+def write(path, name, tile, count):
+  name += '.' + str(count)
+  print path + name  
+  with open(path + name, 'ab') as f:
+    f.write(tile.SerializeToString())
+
+###############################################################################
+
+def createReferenceSpeedTiles(path, fileName, avgspdlist, count):
+  #bucketize avg speeds into 20%, 40%, 60% and 80% reference speed buckets
+  size = len(avgspdlist)
+  p20 = avgspdlist[int(math.ceil((size * 20) / 100)) - 1]
+  p40 = avgspdlist[int(math.ceil((size * 40) / 100)) - 1]
+  p60 = avgspdlist[int(math.ceil((size * 60) / 100)) - 1]
+  p80 = avgspdlist[int(math.ceil((size * 80) / 100)) - 1]
+  
+  print ('for '+ fileName + ' :: reference speeds(20/40/60/80) :: ' + str(p20) + ',' + str(p40) + ',' + str(p60) + ',' + str(p80))
+  createRefSpeedTiles(path, fileName, count, p20, p40, p60, p80)
+  
+
+def createRefSpeedTiles(path, fileName, count, p20, p40, p60, p80):
+  log.debug('createRefSpeedTiles ###############################################################################')
+
+  subtile=None
+  tile = speedtile_pb2.SpeedTile()
+  subtile = tile.subtiles.add()
+  #calculate 4 ref speeds for each segment
+  subtile.referenceSpeed20.append(p20)
+  subtile.referenceSpeed40.append(p40)
+  subtile.referenceSpeed60.append(p60)
+  subtile.referenceSpeed80.append(p80)
+
+  print subtile
+
+  #get the last one written
+  if subtile is not None:
+    write(path, fileName, subtile, count)
+    del subtile
+    del tile
+
+
+#Read in protobuf files from the datastore output in AWS to read in the lengths, speeds & next segment ids and generate the segment speed files in proto output format
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description='Generate speed tiles', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+  parser.add_argument('--spd-tile', type=str, help='The public data extract speed tile containing the average speeds per segment per hour of day for one week', required=True)
+  parser.add_argument('--ref-tile-path', type=str, help='The public data extract speed tile containing the average speeds per segment per hour of day for one week', required=True)
+  parser.add_argument('--output-prefix', type=str, help='The file name prefix to give to output tiles. The first tile will have no suffix, after that they will be numbered starting at 1. e.g. tile.ref, tile.ref.1, tile.ref.2', default='tile.ref')
+  parser.add_argument('--verbose', '-v', help='Turn on verbose output i.e. DEBUG level logging', action='store_true')
+
+  # parse the arguments
+  args = parser.parse_args()
+
+  print 'getting avg speeds from pb speed tile extracts'
+  avgspdlist = createAvgSpeedList(args.spd_tile)
+  
+  count = 0
+  #print 'create reference speed tiles for each segment'
+  createReferenceSpeedTiles(args.ref_tile_path, args.output_prefix, avgspdlist, count)
+
+  if args.verbose:
+    log.debug('loop over segments ###############################################################################')
+    for k,v in segments.iteritems():
+      log.debug('k=' + str(k) + ' | v=' + str(v))
+    log.debug('DONE loop over segments ###############################################################################')
+
+  print 'done'
+

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -86,13 +86,13 @@ def createAvgSpeedList(fileNames):
   return segments
 
 ###############################################################################
-def createRefSpeedTile(path, fileName, speedListPerSegment):
+def createRefSpeedTile(path, fileName, speedListPerSegment, level, index):
   log.debug('createRefSpeedTiles ###############################################################################')
 
   tile = speedtile_pb2.SpeedTile()
   st = tile.subtiles.add()
-  #st.level = 0 #TODO: get from osmlr
-  #st.index = 415 #TODO: get from osmlr
+  st.level = level
+  st.index = index
   st.startSegmentIndex = 0
   st.totalSegments = len(speedListPerSegment)
   st.subtileSegments = len(speedListPerSegment)
@@ -340,7 +340,7 @@ if __name__ == "__main__":
     print("Ref output filename: " + ref_tile_file)
 
   print 'create reference speed tiles for each segment'
-  createRefSpeedTile(args.ref_tile_path, ref_tile_file, speedListPerSegment)
+  createRefSpeedTile(args.ref_tile_path, ref_tile_file, speedListPerSegment, args.level, args.tile_id)
 
   print 'done'
 

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -49,11 +49,16 @@ def createAvgSpeedList(fileNames):
     with open(fileName, 'rb') as f:
       spdtile.ParseFromString(f.read())
 
+    log.debug('Process ' + fileName)
+    subtileCount = 1;
     #we now need to retrieve all of the speeds for each segment in this tile
     for subtile in spdtile.subtiles:
+      log.debug('>>>>> subtileCount per file=' + str(subtileCount))
+      subtileCount += 1
 
       #make sure that there are enough lists in the list for all segments
       missing = spdtile.subtiles[0].totalSegments - len(segments)
+      log.debug('spdtile.subtiles[0].totalSegments=' + str(spdtile.subtiles[0].totalSegments) + ' | len(segments)=' + str(len(segments)) + ' | missing=' + str(missing))
       if missing > 0:
         segments.extend([ [] for i in range(0, missing) ])
       
@@ -61,16 +66,19 @@ def createAvgSpeedList(fileNames):
       entries = subtile.unitSize / subtile.entrySize
       print '# of entries per segment : ' + str(entries)
       for i, speed in enumerate(subtile.speeds):
+        segmentIndex = subtile.startSegmentIndex + int(math.floor(i/entries))
+        log.debug('SPEED: i=' + str(i) + ' | segmentIndex=' + str(segmentIndex) + ' | segmentId=' + str((segmentIndex<<25)|(subtile.index<<3)|subtile.level) + ' | speed=' + str(speed))
         if speed > 0:
-          segments[subtile.startSegmentIndex + int(math.floor(i/entries))].append(speed)
+          segments[segmentIndex].append(speed)
         if speed > 200:
-          log.debug('INVALID SPEED:: index=' + str(i) + ' | speeds=' + str(speed) + '| startSegmentIndex= ' + str(subtile.startSegmentIndex + int(math.floor(i/entries))))
+          log.error('INVALID SPEED: i=' + str(i) + ' | segmentIndex=' + str(segmentIndex) + ' | segmentId=' + str((segmentIndex<<25)|(subtile.index<<3)|subtile.level) + ' | speed=' + str(speed))
 
   #sort each list of speeds per segment
   for i, segment in enumerate(segments):
     if len(segment) > 0:
       print '# of valid average speeds in segment ' + str(i) + ' is ' + str(len(segment))
     segment.sort()
+    log.debug('SORTED SPEEDS: segmentIndex=' + str(i) + ' | speeds=' + str(segment))
 
   return segments
 
@@ -249,13 +257,6 @@ if __name__ == "__main__":
   
   print 'create reference speed tiles for each segment'
   createRefSpeedTile(args.ref_tile_path, args.ref_tile_file, speedListPerSegment)
-
-  if args.verbose:
-    log.debug('loop over segments ###############################################################################')
-    for i, speed in enumerate(speedListPerSegment):
-      log.debug('index=' + str(i) + ' | speeds=' + str(speed))
-
-    log.debug('DONE loop over segments ###############################################################################')
 
   print 'done'
 

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -10,6 +10,8 @@ import botocore
 import shutil
 import gzip
 import logging as log
+from Queue import Queue
+from threading import Thread
 
 try:
   import speedtile_pb2
@@ -27,10 +29,11 @@ maxy_ = 90
 def get_tile_count(filename):
   #lets load the protobuf speed tile
   spdtile = speedtile_pb2.SpeedTile()
-  with open(directory + key, 'rb') as f:
+  with open(filename, 'rb') as f:
     spdtile.ParseFromString(f.read())
-  # 0 based so subtract 1
-  return int(round(spdtile.subtiles[0].totalSegments / (spdtile.subtiles[0].subtileSegments * 1.0))) - 1
+  if spdtile.subtiles[0].totalSegments <= spdtile.subtiles[0].subtileSegments:
+    return 0
+  return int(math.ceil(spdtile.subtiles[0].totalSegments / (spdtile.subtiles[0].subtileSegments * 1.0)))
 
 ###############################################################################
 ### tile 2415
@@ -149,6 +152,7 @@ class Tiles(object):
 
   # get the File based on tile_id and level
   def GetFile(self, tile_id, level):
+
     max_length = self.Digits(self.max_tile_id)
 
     remainder = max_length % 3
@@ -159,16 +163,47 @@ class Tiles(object):
     if level == 0:
       file_suffix = '{:,}'.format(int(pow(10, max_length)) + tile_id).replace(',', '/')
       file_suffix += "."
-      file_suffix += "spd.0"
+      file_suffix += "spd"
       file_suffix = "0" + file_suffix[1:]
       return file_suffix
 
     #it was something else
     file_suffix = '{:,}'.format(level * int(pow(10, max_length)) + tile_id).replace(',', '/')
     file_suffix += "."
-    file_suffix += "spd.0"
-
+    file_suffix += "spd"
     return file_suffix
+
+#this is from:
+#http://code.activestate.com/recipes/577187-python-thread-pool/
+
+class Worker(Thread):
+    """Thread executing tasks from a given tasks queue"""
+    def __init__(self, tasks):
+        Thread.__init__(self)
+        self.tasks = tasks
+        self.daemon = True
+        self.start()
+
+    def run(self):
+        while True:
+            func, args, kargs = self.tasks.get()
+            try: func(*args, **kargs)
+            except Exception, e: print e
+            self.tasks.task_done()
+
+class ThreadPool:
+    """Pool of threads consuming tasks from a queue"""
+    def __init__(self, num_threads):
+        self.tasks = Queue(num_threads)
+        for _ in range(num_threads): Worker(self.tasks)
+
+    def add_task(self, func, *args, **kargs):
+        """Add a task to the queue"""
+        self.tasks.put((func, args, kargs))
+
+    def wait_completion(self):
+        """Wait for completion of all the tasks in the queue"""
+        self.tasks.join()
 
 ###############################################################################
 
@@ -202,9 +237,24 @@ if __name__ == "__main__":
 
   ################################################################################
   # download the speed tiles from aws and decompress
+  spdFileNames = []
   if not args.local:
-    log.debug('Download the speed tiles from AWS and decompress...')
-    spdFileNames = []
+
+    # work function for our threads.  Downloads and decompresses the speed tile
+    def work(bucket, directory, filename):
+      s3 = boto3.client('s3')
+      try:
+        s3.download_file(bucket, filename + ".gz", directory + filename + ".gz")
+      except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == "404":
+          print "File not found in bucket! " + filename + ".gz"
+          raise
+      decompressedFile = gzip.GzipFile(directory + filename + ".gz", mode='rb')
+      with open(directory + filename, 'w') as outfile:
+        outfile.write(decompressedFile.read())
+      print('[INFO] downloaded and decompressed file: ' + filename + '.gz from s3 bucket: ' + bucket)
+
+    #our work dir.  deleted everytime if exists
     directory = "ref_working_dir/"
     shutil.rmtree(directory, ignore_errors=True)
     tile_hierarchy = TileHierarchy()
@@ -212,31 +262,58 @@ if __name__ == "__main__":
 
     s3 = boto3.client('s3')
 
+    #get the first tile *.0.gz so that we can determine the number of subtiles we have
+    # if they are separated into subtiles
+    print('[INFO] starting download from s3 bucket: ' + args.bucket)
     weeks_per_year = 52
     week = 0
+    # for every week in the year
     while ( week < weeks_per_year):
       key = key_prefix + str(week) + "/"
       file_name = tile_hierarchy.levels[args.level].GetFile(args.tile_id, args.level)
       key += file_name
       try:
-        file_path = os.path.dirname(key + ".gz" )
+        file_path = os.path.dirname(key + ".0.gz" )
+        # create the directory for the tiles
         if not os.path.exists(directory + file_path):
           try:
             os.makedirs(directory + file_path)
           except OSError as e:
             if e.errno != errno.EEXIST:
               raise
-        with open(directory + key + ".gz" , "wb") as f:
-          s3.download_fileobj(args.bucket, key + ".gz", f)
+        #download the file
+        s3.download_file(args.bucket, key + ".0.gz", (directory + key + ".0.gz"))
       except botocore.exceptions.ClientError as e:
         if e.response['Error']['Code'] != "404":
           raise
-      decompressedFile = gzip.GzipFile(directory + key + ".gz", mode='rb')
-      with open(directory + key , 'w') as outfile:
+        else:
+          week += 1
+          continue
+      print('[INFO] downloaded and decompressed file: ' + (key + ".0.gz") + ' from s3 bucket: ' + args.bucket)
+      #decompress the file
+      decompressedFile = gzip.GzipFile(directory + key + ".0.gz", mode='rb')
+      with open(directory + key + ".0", 'w') as outfile:
         outfile.write(decompressedFile.read())
 
-      spdFileNames.append(outfile.name)
+      #append the file name
+      spdFileNames.append(os.path.abspath(outfile.name))
+
+      #if everything is in one tile, then we are done.
+      if not args.no_separate_subtiles:
+        subtile_suffix = get_tile_count(directory + key + ".0")
+
+        # create a thread pool based on the subtile count, download, and decompress them
+        if subtile_suffix != 0:
+          p=ThreadPool(subtile_suffix)
+          i = 1;
+          while ( i < subtile_suffix):
+            p.add_task(work, args.bucket, directory, key + "." + str(i))
+            spdFileNames.append(os.path.abspath(directory + key + "." + str(i)))
+            i += 1
+          p.wait_completion()
+
       week += 1
+
   ################################################################################
 
   print 'getting avg speeds from list of protobuf speed tile extracts'

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -17,7 +17,13 @@ except ImportError:
   print 'You need to generate protobuffer source via: protoc --python_out . --proto_path ../proto ../proto/*.proto'
   sys.exit(1)
 
-#wget https://s3.amazonaws.com/speed-extracts/2017/0/0/002/415.spd.*.gz
+def get_tile_count(filename):
+  #lets load the protobuf speed tile
+  spdtile = speedtile_pb2.SpeedTile()
+  with open(directory + key, 'rb') as f:
+    spdtile.ParseFromString(f.read())
+  # 0 based so subtract 1
+  return int(round(spdtile.subtiles[0].totalSegments / (spdtile.subtiles[0].subtileSegments * 1.0))) - 1
 
 ###############################################################################
 ### tile 2415

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -212,7 +212,6 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser(description='Generate speed tiles', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
   parser.add_argument('--speedtile-list', type=str, nargs='+', help='A list of the PDE speed tiles containing the average speeds per segment per hour of day for one week')
   parser.add_argument('--ref-tile-path', type=str, help='The public data extract speed tile containing the average speeds per segment per hour of day for one week', required=True)
-  parser.add_argument('--ref-tile-file', type=str, help='The ref tile file name.')
   parser.add_argument('--bucket', type=str, help='AWS bucket location', required=True)
   parser.add_argument('--year', type=str, help='The year you wish to get', required=True)
   parser.add_argument('--level', type=int, help='The level to target', required=True)
@@ -317,15 +316,23 @@ if __name__ == "__main__":
   ################################################################################
 
   print 'getting avg speeds from list of protobuf speed tile extracts'
+  ref_tile_file = None
   if not args.local:
     log.debug('AWS speed processing...')
     speedListPerSegment = createAvgSpeedList(spdFileNames)
+    ref_tile_file = os.path.splitext(os.path.splitext(os.path.basename(spdFileNames[0]))[0])[0]
+    ref_tile_file += ".ref"
   else:
     log.debug('LOCAL speed processing...')
     speedListPerSegment = createAvgSpeedList(args.speedtile_list)
-  
+    ref_tile_file = os.path.splitext(os.path.splitext(os.path.basename(args.speedtile_list[0]))[0])[0]
+    ref_tile_file += ".ref"
+
+  if args.verbose:
+    print("Ref output filename: " + ref_tile_file)
+
   print 'create reference speed tiles for each segment'
-  createRefSpeedTile(args.ref_tile_path, args.ref_tile_file, speedListPerSegment)
+  createRefSpeedTile(args.ref_tile_path, ref_tile_file, speedListPerSegment)
 
   if args.verbose:
     log.debug('loop over segments ###############################################################################')

--- a/scripts/make_ref_speeds.py
+++ b/scripts/make_ref_speeds.py
@@ -152,14 +152,14 @@ class Tiles(object):
     if level == 0:
       file_suffix = '{:,}'.format(int(pow(10, max_length)) + tile_id).replace(',', '/')
       file_suffix += "."
-      file_suffix += "spd.0.gz"
+      file_suffix += "spd.0"
       file_suffix = "0" + file_suffix[1:]
       return file_suffix
 
     #it was something else
     file_suffix = '{:,}'.format(level * int(pow(10, max_length)) + tile_id).replace(',', '/')
     file_suffix += "."
-    file_suffix += "spd.0.gz"
+    file_suffix += "spd.0"
 
     return file_suffix
 

--- a/scripts/make_ref_speeds_local.sh
+++ b/scripts/make_ref_speeds_local.sh
@@ -22,7 +22,7 @@ echo "level=${level} tile_index=${tile_index}"
 echo "Removing ${extract}.ref..."
 rm -f ${extract}.ref
 
-./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --ref-tile-file ${y}.ref --verbose
+./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --ref-tile-file ${y}.ref --local --verbose
 
 ######################################################################
 x=037
@@ -37,7 +37,7 @@ echo "level=${level} tile_index=${tile_index}"
 echo "Removing ${extract}.ref..."
 rm -f ${extract}.ref
 
-./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --ref-tile-file ${y}.ref --verbose
+./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --ref-tile-file ${y}.ref --local --verbose
 
 ######################################################################
 x=037
@@ -52,5 +52,5 @@ echo "level=${level} tile_index=${tile_index}"
 echo "Removing ${extract}.ref..."
 rm -f ${extract}.ref
 
-./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --ref-tile-file ${y}.ref --verbose
+./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --ref-tile-file ${y}.ref --local --verbose
 

--- a/scripts/make_ref_speeds_local.sh
+++ b/scripts/make_ref_speeds_local.sh
@@ -22,7 +22,7 @@ echo "level=${level} tile_index=${tile_index}"
 echo "Removing ${extract}.ref..."
 rm -f ${extract}.ref
 
-./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --ref-tile-file ${y}.ref --local --verbose
+./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --local --verbose
 
 ######################################################################
 x=037
@@ -37,7 +37,7 @@ echo "level=${level} tile_index=${tile_index}"
 echo "Removing ${extract}.ref..."
 rm -f ${extract}.ref
 
-./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --ref-tile-file ${y}.ref --local --verbose
+./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --local --verbose
 
 ######################################################################
 x=037
@@ -52,5 +52,5 @@ echo "level=${level} tile_index=${tile_index}"
 echo "Removing ${extract}.ref..."
 rm -f ${extract}.ref
 
-./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --ref-tile-file ${y}.ref --local --verbose
+./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --local --verbose
 

--- a/scripts/make_ref_speeds_local.sh
+++ b/scripts/make_ref_speeds_local.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+######################################################################
+### YEAR/WEEK/X/Y.file contains all the hour-by-hour speeds and count indexes
+### 2017/<week>/<level/<tileid>
+bucket="speed-extracts"
+year=2017
+week=0
+extract_base_dir="speed-extracts/${year}/${week}"
+
+
+######################################################################
+x=002
+y=415
+tile_index=2415
+level=0
+extract_path="${extract_base_dir}/${level}/${x}/"
+extract="${extract_path}${y}"
+speedtile_list=`ls ${extract}.spd.* | grep -v "gz$" | tr '\n' ' '`
+echo "speedtile_list=${speedtile_list}"
+echo "level=${level} tile_index=${tile_index}"
+echo "Removing ${extract}.ref..."
+rm -f ${extract}.ref
+
+./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --ref-tile-file ${y}.ref --verbose
+
+######################################################################
+x=037
+y=740
+tile_index=37740
+level=1
+extract_path="${extract_base_dir}/${level}/${x}/"
+extract="${extract_path}${y}"
+speedtile_list=`ls ${extract}.spd.* | grep -v "gz$" | tr '\n' ' '`
+echo "speedtile_list=${speedtile_list}"
+echo "level=${level} tile_index=${tile_index}"
+echo "Removing ${extract}.ref..."
+rm -f ${extract}.ref
+
+./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --ref-tile-file ${y}.ref --verbose
+
+######################################################################
+x=037
+y=741
+tile_index=37741
+level=1
+extract_path="${extract_base_dir}/${level}/${x}/"
+extract="${extract_path}${y}"
+speedtile_list=`ls ${extract}.spd.* | grep -v "gz$" | tr '\n' ' '`
+echo "speedtile_list=${speedtile_list}"
+echo "level=${level} tile_index=${tile_index}"
+echo "Removing ${extract}.ref..."
+rm -f ${extract}.ref
+
+./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --ref-tile-file ${y}.ref --verbose
+

--- a/scripts/make_ref_speeds_local.sh
+++ b/scripts/make_ref_speeds_local.sh
@@ -54,3 +54,12 @@ rm -f ${extract}.ref
 
 ./make_ref_speeds.py --speedtile-list ${speedtile_list} --bucket ${bucket} --year ${year} --level ${level} --tile-id ${tile_index} --ref-tile-path ${extract_path} --local --verbose
 
+######################################################################
+# gzip the ref files
+files=`find ${extract_base_dir} -type f | grep ".ref$"`
+for i in ${files}
+do
+  echo "gzip ${i}..."
+  gzip -c ${i} > ${i}.gz
+done
+

--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -234,7 +234,6 @@ def createSpeedTiles(lengths, fileName, subTileSize, nextName, separate, segment
       if nextSegments:
         speeds = [int(round(length / n['duration'] * 3.6)) for nid, n in nextSegments.iteritems()]
         # assign speed in kph
-        subtile.speeds.append(max(speeds) if nextSegments else 0)
         #we do not want to include the invalid speeds
         if 0 < max(speeds) and max(speeds) <= 200:
           subtile.speeds.append(max(speeds) if nextSegments else 0)

--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -235,10 +235,10 @@ def createSpeedTiles(lengths, fileName, subTileSize, nextName, separate, segment
         speeds = [int(round(length / n['duration'] * 3.6)) for nid, n in nextSegments.iteritems()]
         maxSpeed = max(speeds)
         #we do not want to include the invalid speeds
-        if 0 < maxSpeed and maxSpeed <= 200:
+        if 0 <= maxSpeed and maxSpeed <= 160:
           subtile.speeds.append(maxSpeed if nextSegments else 0)
         else:
-          log.error('**********INVALID SPEEDS > 200 KPH: ' + str(maxSpeed))
+          log.error('**********INVALID SPEEDS > 160 KPH: ' + str(maxSpeed))
 
       #any time its a dead one we put in 0's for the data
       minDuration = min([n['duration'] for nid, n in nextSegments.iteritems()]) if nextSegments else 0

--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -235,18 +235,19 @@ def createSpeedTiles(lengths, fileName, subTileSize, nextName, separate, segment
         speeds = [int(round(length / n['duration'] * 3.6)) for nid, n in nextSegments.iteritems()]
         # assign speed in kph
         #we do not want to include the invalid speeds
-        if 0 < max(speeds) and max(speeds) <= 200:
+        if 0 <= max(speeds) and max(speeds) <= 160:
           subtile.speeds.append(max(speeds) if nextSegments else 0)
         else:
-          log.debug('**********INVALID SPEEDS > 200 KPH :: '+ str(max(speeds)))
+          log.debug('**********INVALID SPEEDS > 160 KPH :: '+ str(max(speeds)))
 
       #any time its a dead one we put in 0's for the data
       minDuration = min([n['duration'] for nid, n in nextSegments.iteritems()]) if nextSegments else 0
 
       if nextSegments:
-        log.debug('segmentId=' + str((k<<25)|(extractInfo['index']<<3)|extractInfo['level']) + ' | hour=' + str(i) + ' | nextSegments=' + str(nextSegments) + ' | length=' + str(length) + ' | minDuration=' + str(minDuration) + ' | speed=' + str(max(speeds)) + ' | varSpeed=' + str(variance(speeds)))
+        log.debug('segmentId=' + str((k<<25)|(extractInfo['index']<<3)|extractInfo['level']) + ' | hour=' + str(i) + ' | nextSegments=' + str(nextSegments) + ' | length=' + str(length) + ' | minDuration=' + str(minDuration) + ' | speed=' + str(max(subtile.speeds)) + ' | varSpeed=' + str(variance(subtile.speeds)))
 
-      subtile.speedVariances.append(variance(speeds) if nextSegments else 0)
+      #get variance on valid speeds
+      subtile.speedVariances.append(variance(subtile.speeds) if nextSegments else 0)
       subtile.prevalences.append(prevalence(sum([n['count'] for nid, n in nextSegments.iteritems()]) if nextSegments else 0))
       subtile.nextSegmentIndices.append(len(subtile.nextSegmentIds) if 1 else 0)
       subtile.nextSegmentCounts.append(len(nextSegments) if nextSegments else 0)

--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -238,7 +238,7 @@ def createSpeedTiles(lengths, fileName, subTileSize, nextName, separate, segment
         if 0 < maxSpeed and maxSpeed <= 200:
           subtile.speeds.append(maxSpeed if nextSegments else 0)
         else:
-          log.error('**********INVALID SPEEDS > 200 KPH' + str(maxSpeed))
+          log.error('**********INVALID SPEEDS > 200 KPH: ' + str(maxSpeed))
 
       #any time its a dead one we put in 0's for the data
       minDuration = min([n['duration'] for nid, n in nextSegments.iteritems()]) if nextSegments else 0

--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -233,18 +233,18 @@ def createSpeedTiles(lengths, fileName, subTileSize, nextName, separate, segment
       # create speed list in kph instead of meters per second
       if nextSegments:
         speeds = [int(round(length / n['duration'] * 3.6)) for nid, n in nextSegments.iteritems()]
-        # assign speed in kph
+        maxSpeed = max(speeds)
         #we do not want to include the invalid speeds
-        if 0 < max(speeds) and max(speeds) <= 200:
-          subtile.speeds.append(max(speeds) if nextSegments else 0)
+        if 0 < maxSpeed and maxSpeed <= 200:
+          subtile.speeds.append(maxSpeed if nextSegments else 0)
         else:
-          log.debug('**********INVALID SPEEDS > 200 KPH :: '+ str(max(speeds)))
+          log.error('**********INVALID SPEEDS > 200 KPH' + str(maxSpeed))
 
       #any time its a dead one we put in 0's for the data
       minDuration = min([n['duration'] for nid, n in nextSegments.iteritems()]) if nextSegments else 0
 
       if nextSegments:
-        log.debug('segmentId=' + str((k<<25)|(extractInfo['index']<<3)|extractInfo['level']) + ' | hour=' + str(i) + ' | nextSegments=' + str(nextSegments) + ' | length=' + str(length) + ' | minDuration=' + str(minDuration) + ' | speed=' + str(max(speeds)) + ' | varSpeed=' + str(variance(speeds)))
+        log.debug('segmentId=' + str((k<<25)|(extractInfo['index']<<3)|extractInfo['level']) + ' | hour=' + str(i) + ' | nextSegments=' + str(nextSegments) + ' | length=' + str(length) + ' | minDuration=' + str(minDuration) + ' | speed=' + str(maxSpeed) + ' | varSpeed=' + str(variance(speeds)))
 
       subtile.speedVariances.append(variance(speeds) if nextSegments else 0)
       subtile.prevalences.append(prevalence(sum([n['count'] for nid, n in nextSegments.iteritems()]) if nextSegments else 0))

--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -221,9 +221,6 @@ def createSpeedTiles(lengths, fileName, subTileSize, nextName, separate, segment
       tile, subtile, nextTile, nextSubtile = next(k, len(lengths), nextName, subTileSize, extractInfo)
 
 
-    #TODO
-    #subtile.referenceSpeeds.append(random.randint(20, 100) if length > 0 else 0)
-
     #do all the entries
     for i in range(0 + minHour, subtile.unitSize/subtile.entrySize + minHour):
       #if we have data get it
@@ -244,7 +241,7 @@ def createSpeedTiles(lengths, fileName, subTileSize, nextName, separate, segment
       subtile.speeds.append(max(speeds) if nextSegments else 0)
 
       if nextSegments:
-        log.debug('segmentId=' + str((k<<25)|(extractInfo['index']<<3)|extractInfo['level']) + ' | nextSegments=' + str(nextSegments) + ' | length=' + str(length) + ' | minDuration=' + str(minDuration) + ' | speed=' + str(max(speeds)) + ' | varSpeed=' + str(variance(speeds)))
+        log.debug('segmentId=' + str((k<<25)|(extractInfo['index']<<3)|extractInfo['level']) + ' | hour=' + str(i) + ' | nextSegments=' + str(nextSegments) + ' | length=' + str(length) + ' | minDuration=' + str(minDuration) + ' | speed=' + str(max(speeds)) + ' | varSpeed=' + str(variance(speeds)))
 
       subtile.speedVariances.append(variance(speeds) if nextSegments else 0)
       subtile.prevalences.append(prevalence(sum([n['count'] for nid, n in nextSegments.iteritems()]) if nextSegments else 0))

--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -220,7 +220,6 @@ def createSpeedTiles(lengths, fileName, subTileSize, nextName, separate, segment
       #set up new pbf messages to write into
       tile, subtile, nextTile, nextSubtile = next(k, len(lengths), nextName, subTileSize, extractInfo)
 
-
     #do all the entries
     for i in range(0 + minHour, subtile.unitSize/subtile.entrySize + minHour):
       #if we have data get it
@@ -234,11 +233,16 @@ def createSpeedTiles(lengths, fileName, subTileSize, nextName, separate, segment
       # create speed list in kph instead of meters per second
       if nextSegments:
         speeds = [int(round(length / n['duration'] * 3.6)) for nid, n in nextSegments.iteritems()]
+        # assign speed in kph
+        subtile.speeds.append(max(speeds) if nextSegments else 0)
+        #we do not want to include the invalid speeds
+        if 0 < max(speeds) and max(speeds) <= 200:
+          subtile.speeds.append(max(speeds) if nextSegments else 0)
+        else:
+          log.debug('**********INVALID SPEEDS > 200 KPH :: '+ str(max(speeds)))
 
       #any time its a dead one we put in 0's for the data
       minDuration = min([n['duration'] for nid, n in nextSegments.iteritems()]) if nextSegments else 0
-      # assign speed in kph
-      subtile.speeds.append(max(speeds) if nextSegments else 0)
 
       if nextSegments:
         log.debug('segmentId=' + str((k<<25)|(extractInfo['index']<<3)|extractInfo['level']) + ' | hour=' + str(i) + ' | nextSegments=' + str(nextSegments) + ' | length=' + str(length) + ' | minDuration=' + str(minDuration) + ' | speed=' + str(max(speeds)) + ' | varSpeed=' + str(variance(speeds)))


### PR DESCRIPTION
This is a WIP.  I still need to hook up loading of files from aws, queuing, etc.
This creates a separate reference speed tile using the same speedtile.proto.  It will just contain 4 reference speed buckets (20%, 40%, 60% and 80%).

example to run:
./make_ref_speeds.py --speedtile-list speed-extracts/2017/0/0/002/415.spd.0 speed-extracts/2017/0/0/002/415.spd.1 speed-extracts/2017/0/0/002/415.spd.2 --ref-tile-path speed-extracts/2017/0/0/002/ --output-prefix 415.ref

Reference speed tiles for 0/002/415.ref, 1/037/740.ref and 1/037/741.ref are currently loaded in speed-extracts bucket.