### PR TITLE
work around batch job size limitation by sending prefixes only

### DIFF
--- a/scripts/submit-work-service.py
+++ b/scripts/submit-work-service.py
@@ -132,7 +132,9 @@ def build_jobs(dictionary, batch_client, job_queue, job_def, work_bucket, datast
         tile_index = str(key[2])
         tile_id = str(((key[2]) << 3) | key[1])
         job_name = str(key[0]) + '_' + str(tile_id)
-        files = ','.join(val)
+        # just use the shared prefixes of the files up to the last directory
+        files = set([ f[:f.rfind('/') + 1] for f in val ])
+        files = ','.join(files)
 
         # set memory for the job based on how
         #   many files we need to process


### PR DESCRIPTION
we were having an issue where the jobs were so big that amazon batch wouldnt let us get them. this was because we send all the files needed to download for a job as a string, so the list can be quite large. instead of sending all the files we send the prefixes. this means that the batch job must first do an `ls` to get the keys that match the prefixes but this is easy enough and removes the limitation