### PR TITLE
reorganize the orchestration of making histograms in aws

### DIFF
--- a/scripts/submit-work-service.py
+++ b/scripts/submit-work-service.py
@@ -17,266 +17,124 @@ handler.setFormatter(logging.Formatter(fmt='%(asctime)s %(levelname)s %(message)
 logger.addHandler(handler)
 
 def batch_check_queue(batch_client, job_queue):
-    """ check that the job queue is empty before submitting any new work """
+  """ check that the job queue is empty before submitting any new work """
 
-    # set default queue status
-    queue_status = 'idle'
+  # set default queue status
+  queue_status = 'idle'
 
-    logger.info('Checking for existing jobs in the queue.')
-    statuses = ['RUNNING', 'RUNNABLE', 'SUBMITTED', 'PENDING', 'STARTING']
+  logger.info('Checking for existing jobs in the queue.')
+  statuses = ['RUNNING', 'RUNNABLE', 'SUBMITTED', 'PENDING', 'STARTING']
 
-    for status in statuses:
-        response = batch_client.list_jobs(
-            jobQueue=job_queue,
-            jobStatus=status,
-            maxResults=10
-            )
+  for status in statuses:
+    response = batch_client.list_jobs(
+      jobQueue=job_queue,
+      jobStatus=status,
+      maxResults=10
+      )
 
-        if len(response['jobSummaryList']) > 0:
-            logger.info('Found active jobs in state: ' + status)
-            queue_status = 'processing'
+    if len(response['jobSummaryList']) > 0:
+      logger.info('Found active jobs in state: ' + status)
+      queue_status = 'processing'
 
-    return queue_status
+  return queue_status
 
-def s3_clean_work_bucket(s3_resource, work_bucket):
-    """ cull any old work data """
+def get_prefixes_keys(client, bucket, prefixes):
+  keys = []
+  pres = []
+  for prefix in prefixes:
+    token = None
+    first = True
+    while first or token:
+      if token:
+        objects = client.list_objects_v2(Bucket=bucket, Delimiter='/', Prefix=prefix, ContinuationToken=token)
+      else:
+        objects = client.list_objects_v2(Bucket=bucket, Delimiter='/', Prefix=prefix)
+      if 'Contents' in objects:
+        keys.extend([ o['Key'] for o in objects['Contents'] ])
+      if 'CommonPrefixes' in objects:
+        pres.extend([ o['Prefix'] for o in objects['CommonPrefixes'] ])
+      token = objects.get('NextContinuationToken')
+      first = False
+  return pres, keys
 
-    logger.info('Emptying work bucket: ' + work_bucket + '.')
+def get_time_tiles(client, bucket):
+  """ check S3 for new data """
 
-    try:
-        s3_resource.Bucket(work_bucket).objects.delete()
-    except ClientError as e:
-        logger.error('Failed to empty work bucket: ' + work_bucket + '. Aborting!')
-        time.sleep(300)
-        sys.exit([1])
+  logger.info('Getting contents of bucket: ' + bucket)
+  hours, _ = get_prefixes_keys(client, bucket, [''])
+  logger.info('Got %d different hours' % len(hours))
+  levels, _ = get_prefixes_keys(client, bucket, hours)
+  logger.info('Got %d different levels of hours' % len(levels))
+  tiles, _ = get_prefixes_keys(client, bucket, levels)
+  logger.info('Got %d different tiles of levels of hours' % len(tiles))
+  return tiles
 
-def s3_get_data(s3_client, reporter_bucket, max_keys):
-    """ check S3 for new data """
+def submit_jobs(tiles, batch_client, job_queue, job_def, reporter_bucket, datastore_bucket):
+  """ loop over the tiles and create jobs """
 
-    logger.info('Getting contents of bucket: ' \
-        + reporter_bucket \
-        + ', max keys: ' \
-        + str(max_keys) \
-        + '.')
-
-    paginator = s3_client.get_paginator('list_objects_v2')
-    page_iterator = paginator.paginate(
-        Bucket=reporter_bucket,
-        PaginationConfig={'MaxItems': max_keys}
-        )
-
-    keys_array = []
-    for page in page_iterator:
-        if 'Contents' in page:
-            for key in page['Contents']:
-                keys_array.append(key['Key'])
-
-    keys_array.sort()
-    return keys_array
-
-def s3_move_data(keys, work_bucket, reporter_bucket):
-    session = boto3.session.Session()
-    s3_client = session.client('s3')
-    """ move data to working bucket """
-    for key in keys:
-        logger.info('Moving key: ' + key + ' from ' + reporter_bucket + ' to ' + work_bucket + '.')
-        try:
-            s3_client.copy_object(
-                Bucket=work_bucket,
-                Key=key,
-                CopySource=reporter_bucket + '/' + key
-                )
-        except ClientError as e:
-            logger.error('Failed to copy key ' + key + ': %s' % e + '.')
-
-        logger.info('Deleting key: ' + key + ' from ' + reporter_bucket + '.')
-        try:
-            s3_client.delete_object(
-                Bucket=reporter_bucket,
-                Key=key
-                )
-        except ClientError as e:
-            logger.error('Failed to delete key: ' + key + ': %s' % e + '.')
-
-def build_dictionary(keys_array, bucket_interval):
-    """ create a dictionary with a key of type tuple of (time bucket,
-    tile_level, tile_index), with the value as a list of
-    files: dictionary = {(23, 32, 43): 'tuple as key'}
-    dictionary[time_bucket, tile_level, tile_index] = ['/path/1', '/path/2'] """
-
-    dictionary = {}
-    for path in keys_array:
-        # parse epoch
-        epoch = path.split('/')[0]
-        epoch_start = int(epoch.split('_')[0])
-        epoch_end = int(epoch.split('_')[1])
-
-        # calculate the tile id: shift the tile
-        # index 3 bits to the left then add the
-        # tile level.
-        tile_level = int(path.split('/')[1])
-        tile_index = int(path.split('/')[2])
-
-        # create the dictionary, sorting on time_bucket, tile_level, tile_index
-        for time_bucket in range(epoch_start/bucket_interval, epoch_end/bucket_interval + 1):
-            if (time_bucket, tile_level, tile_index) in dictionary:
-                dictionary[(time_bucket, tile_level, tile_index)].append(path)
-            else:
-                dictionary[(time_bucket, tile_level, tile_index)] = [path]
-
-    return dictionary
-
-def build_jobs(dictionary, batch_client, job_queue, job_def, work_bucket, datastore_bucket):
-    """ loop over the dictionary and create jobs """
-
-    logger.info('Building jobs.')
-
-    for key, val in dictionary.items():
-        time_bucket = str(key[0])
-        tile_level = str(key[1])
-        tile_index = str(key[2])
-        tile_id = str(((key[2]) << 3) | key[1])
-        job_name = str(key[0]) + '_' + str(tile_id)
-        # just use the shared prefixes of the files up to the last directory
-        files = set([ f[:f.rfind('/') + 1] for f in val ])
-        files = ','.join(files)
-
-        # set memory/vcpus for the job based
-        #   on how many files we need to process
-        if len(val) < 30:
-            memory = 512
-            vcpus = 1
-        elif 30 <= len(val) < 100:
-            memory = 1024
-            vcpus = 1
-        elif 100 <= len(val) < 300:
-            memory = 2048
-            vcpus = 1
-        elif 300 <= len(val) < 500:
-            memory = 3072
-            vcpus = 2
-        else:
-            memory = 4096
-            vcpus = 2
-        
-        # create our batch job
-        logger.info('Submitting a new job: ' \
-            + job_name \
-            + ', containing ' \
-            + str(len(val)) \
-            + ' file(s). Memory: ' \
-            + str(memory) \
-            + ', vcpus: ' \
-            + str(vcpus) \
-            + '.')
-
-        # NOTE on resources: these will generally run successfully with
-        #   only 128mb specified, but they will fail miserably with only 64mb.
-        #   Currently set to 1024mb for safety. Note that the settings here will
-        #   override whatever the current setting is in the job definition.
-        batch_client.submit_job(
-            jobName=job_name,
-            jobQueue=job_queue,
-            jobDefinition=job_def,
-            parameters={
-                's3_reporter_bucket': work_bucket,
-                's3_datastore_bucket': datastore_bucket,
-                's3_reporter_keys': files,
-                'time_bucket': time_bucket,
-                'tile_id': tile_id,
-                'tile_level': tile_level,
-                'tile_index': tile_index
-            },
-            containerOverrides={
-                'memory': memory,
-                'vcpus': vcpus,
-                'command': [
-                    '/scripts/work.py',
-                    '--s3-reporter-bucket',
-                    'Ref::s3_reporter_bucket',
-                    '--s3-datastore-bucket',
-                    'Ref::s3_datastore_bucket',
-                    '--s3-reporter-keys',
-                    'Ref::s3_reporter_keys',
-                    '--time-bucket',
-                    'Ref::time_bucket',
-                    '--tile-id',
-                    'Ref::tile_id',
-                    '--tile-level',
-                    'Ref::tile_level',
-                    '--tile-index',
-                    'Ref::tile_index'
-                ]
-            }
-        )
-
-def split(l, n):
-    size = int(math.ceil(len(l)/float(n)))
-    cutoff = len(l) % n
-    result = []
-    pos = 0
-    for i in range(0, n):
-        end = pos + size if i < cutoff else pos + size - 1
-        result.append(l[pos:end])
-        pos = end
-    return result
+  for tile in tiles:
+    # NOTE on resources: these will generally run successfully with
+    #   only 128mb specified, but they will fail miserably with only 64mb.
+    #   Currently set to 1024mb for safety. Note that the settings here will
+    #   override whatever the current setting is in the job definition.
+    logger.info('Submitting a new job: ' + tile)
+    batch_client.submit_job(
+      jobName=job_name,
+      jobQueue=job_queue,
+      jobDefinition=job_def,
+      parameters={
+        's3_reporter_bucket': reporter_bucket,
+        's3_datastore_bucket': datastore_bucket,
+        's3_reporter_prefix': tile,
+      },
+      containerOverrides={
+        'memory': 4096,
+        'vcpus': 1,
+        'command': [
+          '/scripts/work.py',
+          '--s3-reporter-bucket',
+          'Ref::s3_reporter_bucket',
+          '--s3-datastore-bucket',
+          'Ref::s3_datastore_bucket',
+          '--s3-reporter-prefix',
+          'Ref::s3_reporter_prefix',
+        ]
+      }
+    )
 
 env = os.getenv('DATASTORE_ENV', 'BOGUS') # required, 'prod' or 'dev'
 sleep_between_runs = os.getenv('SLEEP_BETWEEN_RUNS', 120) # optional
-max_keys = os.getenv('MAX_KEYS', 100) # optional
-bucket_interval = os.getenv('BUCKET_INTERVAL', 3600) # optional
 
 if env == 'BOGUS':
-    logger.error('DATASTORE_ENV environment variable not set! Exiting.')
-    sys.exit(1)
+  logger.error('DATASTORE_ENV environment variable not set! Exiting.')
+  sys.exit(1)
 else:
-    sleep_between_runs = int(sleep_between_runs)
-    max_keys = int(max_keys)
-    bucket_interval = int(bucket_interval)
-    work_bucket = 'reporter-work-' + env
-    reporter_bucket = 'reporter-drop-' + env
-    datastore_bucket = 'datastore-output-' + env
-    job_queue = 'datastore-' + env
-    job_def = 'datastore-' + env
-    lock_bucket = 'datastore-lambda-lock-' + env
+  sleep_between_runs = int(sleep_between_runs)
+  reporter_bucket = 'reporter-drop-' + env
+  datastore_bucket = 'datastore-output-' + env
+  job_queue = 'datastore-' + env
+  job_def = 'datastore-' + env
 
-# do work
 s3_resource = boto3.resource('s3')
 s3_client = boto3.client('s3')
 batch_client = boto3.client('batch')
 
+#check if we are still working on stuff
 batch_queue_status = batch_check_queue(batch_client, job_queue)
 if batch_queue_status == 'processing':
-    logger.info('Run complete!')
-    logger.info('Sleeping before next run...')
-    time.sleep(sleep_between_runs)
+  logger.info('Run complete!')
+  logger.info('Sleeping before next run...')
+  time.sleep(sleep_between_runs)
 else:
-    logger.info('No jobs in the queue.')
+  #check if there is new tile data to work on
+  logger.info('No jobs in the queue.')
+  tiles = get_time_tiles(s3_client, reporter_bucket)
+  if not tiles:
+    logger.info('Found no tiles! Passing on this run.')
+  else:
+    #make new jobs
+    submit_jobs(tiles, batch_client, job_queue, job_def, reporter_bucket, datastore_bucket)
 
-    # get down to work
-    s3_clean_work_bucket(s3_resource, work_bucket)
-
-    s3_data = s3_get_data(s3_client, reporter_bucket, max_keys)
-
-    # if the array is empty, abort
-    if not s3_data:
-        logger.info('Found no keys! Passing on this run.')
-        logger.info('Run complete!')
-        logger.info('Sleeping before next run...')
-        time.sleep(sleep_between_runs)
-    else:
-        # copy delete data
-        chunks = split(s3_data, 10)
-        threads = []
-        for chunk in chunks:
-            threads.append(threading.Thread(target=s3_move_data, args=(chunk, work_bucket, reporter_bucket)))
-            threads[-1].start()
-        for t in threads:
-            t.join()
-        dictionary = build_dictionary(s3_data, bucket_interval)
-        build_jobs(dictionary, batch_client, job_queue, job_def, work_bucket, datastore_bucket)
-
-        logger.info('Run complete!')
-        logger.info('Sleeping before next run...')
-
-        time.sleep(sleep_between_runs)
+logger.info('Run complete!')
+logger.info('Sleeping before next run...')
+time.sleep(sleep_between_runs)

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -9,6 +9,7 @@ import boto3
 import logging
 import threading
 import math
+import time
 from botocore.exceptions import ClientError
 
 logger = logging.getLogger('make_histograms')
@@ -17,128 +18,158 @@ handler = logging.StreamHandler()
 handler.setFormatter(logging.Formatter(fmt='%(asctime)s %(levelname)s %(message)s'))
 logger.addHandler(handler)
 
-def get_time_key(time_bucket, tile_level, tile_index):
-    # path key: year/month/day/hour/tile_level/tile_index
-    to_time = time.gmtime(time_bucket * 3600)
-    time_key = str(to_time[0]) + '/' + str(to_time[1]) + '/' + str(to_time[2]) + '/' + str(to_time[3]) + '/' + str(tile_level) + '/' + str(tile_index)
-    return time_key
+def parse_prefix(prefix):
+  # input prefix: epochsecond_epochsecond/tile_level/tile_index
+  # dest key: year/month/day/hour/tile_level/tile_index
+  parts = prefix.split('/')
+  epoch = int(parts[0].split('_')[0])
+  to_time = time.gmtime(epoch)
+  dest = str(to_time[0]) + '/' + str(to_time[1]) + '/' + str(to_time[2]) + '/' + str(to_time[3]) + '/' + parts[1] + '/' + parts[2] + '.fb'
+  #time_bucket, tile_id, destination key
+  return int(epoch / 3600), (int(parts[2]) << 3) | int(parts[1]), dest
 
-def upload(time_key, s3_datastore_bucket):
-    logger.info('uploading data to bucket: ' + s3_datastore_bucket)
-    s3_client = boto3.client('s3')
+def convert(time_bucket, tile_id, dest_key):
+  logger.info('running conversion process')
+  fb_out_file = dest_key.split('/')[-1]
+  
+  # TODO: no idea if the exception handling works
+  try:
+    output = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(time_bucket), '-t', str(tile_id), '-f', fb_out_file] + glob.glob('*'), timeout=180, universal_newlines=True, stderr=subprocess.STDOUT)
+    for line in output.splitlines():
+      logger.info(line)
+  except subprocess.CalledProcessError as tilewriter:
+    logger.error('Failed running datastore-histogram-tile-writer: ' + str(tilewriter.returncode) + ' ' + str(tilewriter.output))
+    sys.exit(tilewriter.returncode)
+  logger.info('Finished running conversion')
 
-    uploads = ['.fb']
-    for file_extension in uploads:
-        key = time_key + file_extension
+def upload(dest_key, s3_datastore_bucket):
+  s3_client = boto3.client('s3')
+  with open(dest_key.split('/')[-1], 'rb') as data:
+    logger.info('Uploading to ' + s3_datastore_bucket + ' ' + dest_key)
+    s3_client.put_object(Bucket=s3_datastore_bucket, ContentType='binary/octet-stream', Body=data, Key=dest_key)
 
-        data = open(time_key.rsplit('/', 1)[-1] + file_extension, 'rb')
-        s3_client.put_object(
-            Bucket=s3_datastore_bucket,
-            ContentType='binary/octet-stream',
-            Body=data,
-            Key=key)
-        data.close()
+def delete_keys(keys, s3_reporter_bucket):
+  secs = 2
+  s3_client = boto3.client('s3')
+  for key in keys:
+    logger.info('Deleting from ' + s3_reporter_bucket + ' ' + key)
+    while True:
+      try:
+        s3_client.delete_object(Bucket=s3_reporter_bucket, Key=key)
+        s3_client.head_object(Bucket=s3_reporter_bucket, Key=key)
+      except Exception as e:
+        if e.response['ResponseMetadata']['HTTPStatusCode'] == 404:
+          break
+        logger.error('Failed to delete ' + key + ': ' + str(d))
+        logger.info('Sleeping %d seconds until next try' % secs)
+        time.sleep(secs)
+        secs *= secs
 
-def convert(tile_index, time_bucket, tile_id):
-    logger.info('running conversion process')
-    sys.stdout.flush()
-
-    fb_out_file = str(tile_index) + '.fb'
-
-    # TODO: no idea if the exception handling works
-    try:
-        output = subprocess.check_output(['datastore-histogram-tile-writer', '-b', str(time_bucket), '-t', str(tile_id), '-f', fb_out_file] + glob.glob('*'), timeout=180, universal_newlines=True, stderr=subprocess.STDOUT)
-        for line in output.splitlines():
-            logger.info(line)
-    except subprocess.CalledProcessError as tilewriter:
-        logger.error('Failed running datastore-histogram-tile-writer: ' + str(tilewriter.returncode) + ' ' + str(tilewriter.output))
-        sys.exit(tilewriter.returncode)
-    logger.info('Finished running conversion')
+def delete(keys, s3_reporter_bucket):
+  # delete the files
+  chunks = split(keys, 10)
+  threads = []
+  for chunk in chunks:
+    threads.append(threading.Thread(target=delete_keys, args=(chunk, s3_reporter_bucket)))
+    threads[-1].start()
+  for t in threads:
+    t.join()
 
 def get_files(keys, s3_reporter_bucket, s3_datastore_bucket):
-    for key in keys:
-        object_id = key.rsplit('/', 1)[-1]
-        session = boto3.session.Session()
-        s3_resource = session.resource('s3')
-        logger.info('downloading ' + object_id + ' from s3 bucket: ' + s3_reporter_bucket)
-        try:
-            if key.endswith('.fb'):
-                logger.info('downloading ' + key + ' as ' + object_id + ' from s3 bucket: ' + s3_datastore_bucket)
-                s3_resource.Object(s3_datastore_bucket, key).download_file(object_id)
-            else:
-                logger.info('downloading ' + key + ' as ' + object_id + ' from s3 bucket: ' + s3_reporter_bucket)
-                s3_resource.Object(s3_reporter_bucket, key).download_file(object_id)
-        except Exception as e:
-            logger.error('Failed to download key: %s' % e)
+  for key in keys:
+    object_id = key.rsplit('/', 1)[-1]
+    session = boto3.session.Session()
+    s3_resource = session.resource('s3')
+    logger.info('downloading ' + object_id + ' from s3 bucket: ' + s3_reporter_bucket)
+    try:
+      if key.endswith('.fb'):
+        logger.info('downloading ' + key + ' as ' + object_id + ' from s3 bucket: ' + s3_datastore_bucket)
+        s3_resource.Object(s3_datastore_bucket, key).download_file(object_id)
+      else:
+        logger.info('downloading ' + key + ' as ' + object_id + ' from s3 bucket: ' + s3_reporter_bucket)
+        s3_resource.Object(s3_reporter_bucket, key).download_file(object_id)
+    except Exception as e:
+      logger.error('Failed to download key: %s' % e)
 
 def split(l, n):
-    size = int(math.ceil(len(l)/float(n)))
-    cutoff = len(l) % n
-    result = []
-    pos = 0
-    for i in range(0, n):
-        end = pos + size if i < cutoff else pos + size - 1
-        result.append(l[pos:end])
-        pos = end
-    return result
+  size = int(math.ceil(len(l)/float(n)))
+  cutoff = len(l) % n
+  result = []
+  pos = 0
+  for i in range(0, n):
+    end = pos + size if i < cutoff else pos + size - 1
+    result.append(l[pos:end])
+    pos = end
+  return result
 
-def download_data(prefixes_array, s3_reporter_bucket, s3_datastore_bucket, time_key):
-    client = boto3.client('s3')
-    s3_resource = boto3.resource('s3')
-    
-    # get the keys
-    keys = []
-    for prefix in prefixes_array:
-        token = None
-        first = True
-        while first or token:
-            if token:
-                objects = client.list_objects_v2(Bucket=s3_reporter_bucket, Delimiter='/', Prefix=prefix, ContinuationToken=token)
-            else:
-                objects = client.list_objects_v2(Bucket=s3_reporter_bucket, Delimiter='/', Prefix=prefix)
-            keys.extend([ o['Key'] for o in objects['Contents']])
-            token = objects.get('NextContinuationToken')
-            first = False
-    # add the key for the existing file
-    keys.append(time_key + '.fb')
+def get_prefixes_keys(client, bucket, prefixes):
+  keys = []
+  pres = []
+  for prefix in prefixes:
+    token = None
+    first = True
+    while first or token:
+      if token:
+        objects = client.list_objects_v2(Bucket=bucket, Delimiter='/', Prefix=prefix, ContinuationToken=token)
+      else:
+        objects = client.list_objects_v2(Bucket=bucket, Delimiter='/', Prefix=prefix)
+      if 'Contents' in objects:
+        keys.extend([ o['Key'] for o in objects['Contents'] ])
+      if 'CommonPrefixes' in objects:
+        pres.extend([ o['Prefix'] for o in objects['CommonPrefixes'] ])
+      token = objects.get('NextContinuationToken')
+      first = False
+  return pres, keys
 
-    # download the files
-    keys = split(keys, 10)
-    threads = []
-    for chunk in keys:
-        threads.append(threading.Thread(target=get_files, args=(chunk, s3_reporter_bucket, s3_datastore_bucket)))
-        threads[-1].start()
-    for t in threads:
-        t.join()
+def download_data(prefix, s3_reporter_bucket, s3_datastore_bucket, dest_key):
+  client = boto3.client('s3')
+
+  # get the keys for the files in this tile
+  _, keys = get_prefixes_keys(client, s3_reporter_bucket, [prefix])
+ 
+  # add the key for the existing file
+  keys.append(dest_key)
+
+  # download the files
+  chunks = split(keys, 10)
+  threads = []
+  for chunk in chunks:
+    threads.append(threading.Thread(target=get_files, args=(chunk, s3_reporter_bucket, s3_datastore_bucket)))
+    threads[-1].start()
+  for t in threads:
+    t.join()
+
+  return keys[:-1]
 
 if __name__ == "__main__":
-    # build args
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--s3-reporter-bucket', type=str, help='Bucket (e.g. reporter-work-prod) in which the data we wish to process is located')
-    parser.add_argument('--s3-datastore-bucket', type=str, help='Bucket (e.g. datastore-output-prod) into which we will place transformed data')
-    parser.add_argument('--s3-reporter-keys', type=str, help='S3 object keys which we will operate on, found in the s3_reporter_bucket')
-    parser.add_argument('--time-bucket', type=int, help='The time bucket')
-    parser.add_argument('--tile-id', type=int, help='The tile ID')
-    parser.add_argument('--tile-level', type=int, help='The tile level')
-    parser.add_argument('--tile-index', type=int, help='The tile index')
-    args = parser.parse_args()
+  # build args
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--s3-reporter-bucket', type=str, help='Bucket (e.g. reporter-work-prod) in which the data we wish to process is located')
+  parser.add_argument('--s3-datastore-bucket', type=str, help='Bucket (e.g. datastore-output-prod) into which we will place transformed data')
+  parser.add_argument('--s3-reporter-prefix', type=str, help='S3 prefix under which tiles will be found, should look like epochsecond_epochsecond/level/tile_index')
+  args = parser.parse_args()
 
-    logger.info('reporter input bucket: ' + args.s3_reporter_bucket)
-    logger.info('datastore output bucket: ' + args.s3_datastore_bucket)
-    logger.info('time bucket: ' + str(args.time_bucket))
-    logger.info('tile id: ' + str(args.tile_id))
-    logger.info('tile level: ' + str(args.tile_level))
-    logger.info('tile index: ' + str(args.tile_index))
+  logger.info('reporter input bucket: ' + args.s3_reporter_bucket)
+  logger.info('datastore output bucket: ' + args.s3_datastore_bucket)
+  logger.info('reporter prefix: ' + str(args.s3_reporter_prefix))
 
-    # do work
-    time_key = get_time_key(args.time_bucket, args.tile_level, args.tile_index)
+  #where will this thing end up
+  time_bucket, tile_id, dest_key = parse_prefix(args.s3_reporter_prefix)
 
-    download_data(
-        args.s3_reporter_keys.split(','),
-        args.s3_reporter_bucket,
-        args.s3_datastore_bucket,
-        time_key)
-    convert(args.tile_index, args.time_bucket, args.tile_id)
-    upload(time_key, args.s3_datastore_bucket)
+  #go download all the tiles
+  keys = download_data(args.s3_reporter_prefix, args.s3_reporter_bucket, args.s3_datastore_bucket, dest_key)
 
-    logger.info('run complete')
+  if not keys:
+    logger.error('Prefix was empty!')
+    sys.exit(1)
+
+  #turn the downloaded files into
+  convert(time_bucket, tile_id, dest_key)
+
+  #upload the finished product
+  upload(dest_key, args.s3_datastore_bucket)
+
+  #delete the input data
+  delete(keys, args.s3_reporter_bucket)
+
+  logger.info('run complete')


### PR DESCRIPTION
we used to let the thing that made the jobs move data to a temp bucket and then delete them when all the batch jobs were done. we flip that around about. now we just enumerate the various time tiles as jobs and the workers themselves clean up the data that they find in those time tiles when they run. this should schedule a lot more jobs and has the benefit of now wiping the data until we are sure we uploaded the result to s3. previously we were somehow getting in the state that the worker would wake up and not see the data that the job maker said would be there.