### PR TITLE
speedier speedtiles 

### DIFF
--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -94,19 +94,13 @@ def processSegment(segments, segment, extractInfo, length):
       continue
 
     #get the right segment
-    if segment.SegmentId() not in segments:
-      segments[segment.SegmentId()] = { }
-    hours = segments[segment.SegmentId()]
+    hours = segments.setdefault(segment.SegmentId(), {})
 
     #get the right hour in there
-    if e.EpochHour() not in hours:
-       hours[e.EpochHour()] = { }
-    nexts = hours[e.EpochHour()]
+    nexts = hours.setdefault(e.EpochHour(), {})
 
     #if you dont have the right next segment in there
-    if segment.NextSegmentIds(e.NextSegmentIdx()) not in nexts:
-      nexts[segment.NextSegmentIds(e.NextSegmentIdx())] = {'count': 0, 'duration': 0, 'queue': 0 }
-    totals = nexts[segment.NextSegmentIds(e.NextSegmentIdx())]
+    totals = nexts.setdefault(segment.NextSegmentIds(e.NextSegmentIdx()), {'count': 0, 'duration': 0, 'queue': 0 })
 
     #continuing a previous pair
     totals['count'] += e.Count()

--- a/scripts/make_speeds.py
+++ b/scripts/make_speeds.py
@@ -64,29 +64,23 @@ def unquantise(val):
   raise (hi, lo)
 
 ###############################################################################
-def getSegments(path, extractInfo, lengths):
-  log.debug('getSegments ###############################################################################')
-  log.debug('Looking for level=' + str(extractInfo['level']) + ' and tile_id=' + str(extractInfo['index']) + ' here:' + path)
-  segments = {}
-  for root, dirs, files in os.walk(path):
-    for file in files:
-      if (root + os.sep + file).endswith('.fb'):
-        with open(root + os.sep + file, 'rb') as filehandle:
-          log.info('Loading ' + (root + os.sep + file) + '...')
-          hist = Histogram.GetRootAsHistogram(bytearray(filehandle.read()), 0)
-        level = get_level(hist.TileId())
-        tile_index = get_tile_index(hist.TileId())
-        if (level == extractInfo['level']) and (tile_index == extractInfo['index']):
-          log.info('Processing ' + (root + os.sep + file) + '...')
-          #for each segment
-          for i in range(0, hist.SegmentsLength()):
-            segment = hist.Segments(i)
-            #has to be one we know about and its not tombstoned/markered
-            if segment.EntriesLength() > 0 and segment.SegmentId() < len(lengths) and lengths[segment.SegmentId()] > 0:
-              length = lengths[segment.SegmentId()]
-              processSegment(segments, segment, extractInfo, length)
-        del hist
-  return segments
+def addSegments(file_name, extractInfo, lengths, segments):
+  with open(file_name, 'rb') as filehandle:
+    log.info('Loading %s...' % file_name)
+    hist = Histogram.GetRootAsHistogram(bytearray(filehandle.read()), 0)
+  level = get_level(hist.TileId())
+  tile_index = get_tile_index(hist.TileId())
+  if (level == extractInfo['level']) and (tile_index == extractInfo['index']):
+    log.info('Processing %s...' % file_name)
+    #for each segment
+    for i in range(0, hist.SegmentsLength()):
+      segment = hist.Segments(i)
+      #has to be one we know about and its not tombstoned/markered
+      if segment.EntriesLength() > 0 and segment.SegmentId() < len(lengths) and lengths[segment.SegmentId()] > 0:
+        length = lengths[segment.SegmentId()]
+        processSegment(segments, segment, extractInfo, length)
+    log.info('Processed %s' % file_name)
+  del hist
 
 ###############################################################################
 def processSegment(segments, segment, extractInfo, length):
@@ -118,6 +112,16 @@ def processSegment(segments, segment, extractInfo, length):
     totals['count'] += e.Count()
     totals['duration'] += unquantise(e.DurationBucket()) * e.Count()
     totals['queue'] += (e.Queue()/255.0) * length * e.Count()
+
+###############################################################################
+def getSegments(path, extractInfo, lengths):
+  log.debug('getSegments ###############################################################################')
+  log.debug('Looking for level=' + str(extractInfo['level']) + ' and tile_id=' + str(extractInfo['index']) + ' here:' + path)
+  segments = {}
+  for root, dirs, files in os.walk(path):
+    for file in files:
+      if (root + os.sep + file).endswith('.fb'):
+        addSegments(root + os.sep + file, extractInfo, lengths, segments)
 
 ###############################################################################
 # length in meters, rounded to the nearest meter

--- a/scripts/speed-tile-work.py
+++ b/scripts/speed-tile-work.py
@@ -12,7 +12,9 @@ import datetime
 import calendar
 import logging
 import StringIO
-from botocore.exceptions import ClientError
+import multiprocessing
+import random
+import functools
 
 logger = logging.getLogger('make_speeds')
 logger.setLevel(logging.INFO)
@@ -35,6 +37,23 @@ def url_suffix(tile_level, tile_index):
   suffix = '/' + str(tile_level) + ''.join(suffix) 
   return suffix
 
+def split(l, n):
+  size = int(math.ceil(len(l)/float(n)))
+  cutoff = len(l) % n
+  result = []
+  pos = 0
+  for i in range(0, n):
+    end = pos + size if cutoff == 0 or i < cutoff else pos + size - 1
+    result.append(l[pos:end])
+    pos = end
+  return result
+
+def interrupt_wrapper(func):
+  try:
+    func()
+  except (KeyboardInterrupt, SystemExit):
+    logger.error('Interrupted or killed')
+
 def upload(speed_bucket, level, index, week, speed_tiles):
   logger.info('Uploading data to bucket: ' + speed_bucket)
   client = boto3.client('s3')
@@ -53,7 +72,19 @@ def upload(speed_bucket, level, index, week, speed_tiles):
       Body=zipped.getvalue(),
       Key=key)
 
-def convert(level, index, week, histograms):
+def load(histograms, segments, info, lengths):
+  while True:
+    try:
+      file_name = histograms.get()
+      histograms.task_done()
+      if file_name:
+        make_speeds.addSegments(file_name, info, lengths, segments)
+      else:
+        break
+    except (KeyboardInterrupt, SystemExit) as e:
+      raise e
+
+def convert(level, index, week, histograms, concurrency):
   url = 'http://s3.amazonaws.com/osmlr-tiles/v1.0/pbf' + url_suffix(level, index) + '.osmlr'
   logger.info('Fetching osmlr tile: ' + url)
   osmlr = str(level) + '_' + str(index) + '.osmlr'
@@ -68,35 +99,73 @@ def convert(level, index, week, histograms):
     'description': 'Hourly speeds for the week starting on ' + str(date), 'level': level, 'index': index}
 
   logger.info('Accumulating segment speeds from histograms')
-  segments = make_speeds.getSegments('.', info, lengths)
+  #we share the segments dict in a process safe way
+  manager = multiprocessing.Manager()
+  segments = manager.dict()
+  processes = []
+  #start them up
+  for i in xrange(concurrency):
+    bound = functools.partial(load, histograms, segments, info, lengths)
+    processes.append(multiprocessing.Process(target=interrupt_wrapper, args=(bound,)))
+    processes[-1].start()
+  #wait for them to finish everything then send a sentinel to kill them
+  histograms.join()
+  for i in xrange(concurrency):
+    histograms.put(None)
+  #then wait for them to die
+  for p in processes:
+    if p.is_alive():
+      p.join()
 
   logger.info('Creating speed tiles')
   prefix = url_suffix(int(level), int(index)).split('/')[-1]
   return make_speeds.createSpeedTiles(lengths, prefix + '.spd', 10000, prefix + '.nex', True, segments, info), osmlr
 
-def download(histogram_bucket, tile_level, tile_index, week):
-  #we need to get all the histograms for all the hours of this week
-  resource = boto3.resource('s3')
-  date = datetime.datetime.strptime(week + '/1','%Y/%W/%w')
-  downloaded = []
-  logger.info('Downloading files for week ' + '{d.year}/{d.month}/{d.day} tile {l}/{t}.fb'.format(d=date, l=tile_level, t=tile_index))
-  for hour in range(0, 24 * 7):
-    key = '{d.year}/{d.month}/{d.day}/{d.hour}/{l}/{t}.fb'.format(d=(date + datetime.timedelta(hours=hour)), l=tile_level, t=tile_index)
+def fetch(histogram_bucket, keys, results):
+  session = boto3.session.Session()
+  resource = session.resource('s3')
+  for key in keys:
     try:
-      resource.Object(histogram_bucket, key).download_file(key.replace('/', '_'))
-      downloaded.append(key.replace('/', '_'))
-      logger.info('Downloaded s3://' + histogram_bucket + '/' + key)
+      dest = key.replace('/', '_')
+      resource.Object(histogram_bucket, key).download_file(dest)
+      if os.path.isfile(dest):
+        logger.info('Downloaded s3://' + histogram_bucket + '/' + key)
+        results.put(dest)
+    except (KeyboardInterrupt, SystemExit) as e:
+      raise e
     except Exception as e:
       pass
-  return downloaded
+
+def download(histogram_bucket, tile_level, tile_index, week, concurrency):
+  #we need to get all the histograms for all the hours of this week
+  date = datetime.datetime.strptime(week + '/1','%Y/%W/%w')
+  logger.info('Downloading files for week ' + '{d.year}/{d.month}/{d.day} tile {l}/{t}.fb'.format(d=date, l=tile_level, t=tile_index))
+  keys = []
+  for hour in xrange(0, 24 * 7):
+    key = '{d.year}/{d.month}/{d.day}/{d.hour}/{l}/{t}.fb'.format(d=(date + datetime.timedelta(hours=hour)), l=tile_level, t=tile_index)
+    keys.append(key)
+  random.shuffle(keys)
+  keys = split(keys, concurrency)
+
+  processes = []
+  downloaded = multiprocessing.JoinableQueue()
+  for i in xrange(concurrency):
+    bound = functools.partial(fetch, histogram_bucket, keys[i], downloaded)
+    processes.append(multiprocessing.Process(target=interrupt_wrapper, args=(bound,)))
+    processes[-1].start()
+  for p in processes:
+    if p.is_alive():
+      p.join()
+  return downloaded  
 
 if __name__ == '__main__':
   #build args
   parser = argparse.ArgumentParser()
-  parser.add_argument('--environment', type=str, help='The environment prod or dev to use when computing bucket names and batch job queues and definitions')
-  parser.add_argument('--tile-level', type=int, help='The tile level used to get the input data from the histogram bucket')
-  parser.add_argument('--tile-index', type=int, help='The tile index used to get the input data from the histogram bucket')
-  parser.add_argument('--week', type=str, help='The week used to get the input data from the histogram bucket')
+  parser.add_argument('--environment', type=str, help='The environment prod or dev to use when computing bucket names and batch job queues and definitions', required=True)
+  parser.add_argument('--tile-level', type=int, help='The tile level used to get the input data from the histogram bucket', required=True)
+  parser.add_argument('--tile-index', type=int, help='The tile index used to get the input data from the histogram bucket', required=True)
+  parser.add_argument('--week', type=str, help='The week used to get the input data from the histogram bucket', required=True)
+  parser.add_argument('--concurrency', type=int, help='The week used to get the input data from the histogram bucket', default=1)
   args = parser.parse_args()
 
   #generate the list of the parent tile and all its subtiles, level 0 and 1 only right now
@@ -121,41 +190,44 @@ if __name__ == '__main__':
   job_queue = 'referencetiles-' + args.environment
   job_def = 'referencetiles-' + args.environment
 
-  #for each tile
-  for tile in tiles:
-    logger.info('Histogram input bucket: ' + histogram_bucket)
-    logger.info('Speedtile output bucket: ' + speed_bucket)
-    logger.info('Tile level: ' + str(tile[0]))
-    logger.info('Tile index: ' + str(tile[1]))
-    logger.info('Week: ' + args.week)  
-    #go get the histogram data
-    histograms = download(histogram_bucket, tile[0], tile[1], args.week)
-    if histograms:
-      #make the speed tile
-      speed_tiles, osmlr = convert(tile[0], tile[1], args.week, histograms)
-      #move the speed tile to its destination
-      upload(speed_bucket, tile[0], tile[1], args.week, speed_tiles)
-      # create the corresponding referencetile jobs
-      job_name = '_'.join([args.week.replace('/', '-'), str(tile[0]), str(tile[1])])
-      job = {'environment': args.environment, 'tile_level': str(tile[0]), 'tile_index': str(tile[1]), 'week': args.week}
-      logger.info('Submitting reference tile job ' + job_name)
-      logger.info('Job parameters ' + str(job))
-      submitted = batch_client.submit_job(
-        jobName = job_name,
-        jobQueue = job_queue,
-        jobDefinition = job_def,
-        parameters = job,
-        containerOverrides={
-          'memory': 8192,
-          'vcpus': 2,
-          'command': ['/scripts/ref-tile-work.py', '--environment', 'Ref::environment', '--end-week', 'Ref::week', '--weeks', '52', '--tile-level', 'Ref::tile_level', '--tile-index', 'Ref::tile_index']
-        }
-      )
-      logger.info('Job %s was submitted and got id %s' % (job_name, submitted['jobId']))
-      #clean up the files
-      for f in histograms + speed_tiles + [osmlr]:
-        os.remove(f)
-    else:
-      logger.info('No histogram data');
+  try:
+    #for each tile
+    for tile in tiles:
+      logger.info('Histogram input bucket: ' + histogram_bucket)
+      logger.info('Speedtile output bucket: ' + speed_bucket)
+      logger.info('Tile level: ' + str(tile[0]))
+      logger.info('Tile index: ' + str(tile[1]))
+      logger.info('Week: ' + args.week)  
+      #go get the histogram data
+      histograms = download(histogram_bucket, tile[0], tile[1], args.week, args.concurrency)
+      if histograms:
+        #make the speed tile
+        speed_tiles, osmlr = convert(tile[0], tile[1], args.week, histograms, args.concurrency)
+        #move the speed tile to its destination
+        upload(speed_bucket, tile[0], tile[1], args.week, speed_tiles)
+        # create the corresponding referencetile jobs
+        job_name = '_'.join([args.week.replace('/', '-'), str(tile[0]), str(tile[1])])
+        job = {'environment': args.environment, 'tile_level': str(tile[0]), 'tile_index': str(tile[1]), 'week': args.week}
+        logger.info('Submitting reference tile job ' + job_name)
+        logger.info('Job parameters ' + str(job))
+        submitted = batch_client.submit_job(
+          jobName = job_name,
+          jobQueue = job_queue,
+          jobDefinition = job_def,
+          parameters = job,
+          containerOverrides={
+            'memory': 8192,
+            'vcpus': 2,
+            'command': ['/scripts/ref-tile-work.py', '--environment', 'Ref::environment', '--end-week', 'Ref::week', '--weeks', '52', '--tile-level', 'Ref::tile_level', '--tile-index', 'Ref::tile_index']
+          }
+        )
+        logger.info('Job %s was submitted and got id %s' % (job_name, submitted['jobId']))
+        #clean up the files
+        for f in histograms + speed_tiles + [osmlr]:
+          os.remove(f)
+      else:
+        logger.info('No histogram data')
 
-  logger.info('Run complete')
+    logger.info('Run complete')
+  except (KeyboardInterrupt, SystemExit):
+    logger.error('Interrupted or killed')


### PR DESCRIPTION
it was taking ages to process speed tiles for places where we have really good data coverage (jakarta). so i started by having a shared dict across processes. that took it from 75 minutes to 45. then i removed the synchronization and added a merge step at the end. this runs in about 13 minutes using 7 procs. this seems reasonable enough and should help when the data grows even larger.